### PR TITLE
Feature/add until ref commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,67 @@
+name: "Tests"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "1.x"
+  schedule:
+    - cron:  '* 8 * * *'
+
+jobs:
+  tests:
+    name: "Tests"
+
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      matrix:
+        dependencies:
+          - "locked"
+          - "lowest"
+          - "highest"
+        php-version:
+          - "7.4"
+          - "8.0"
+        operating-system:
+          - "ubuntu-latest"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: pcov
+          tools: phive, composer:v2
+          php-version: "${{ matrix.php-version }}"
+          ini-values: memory_limit=-1
+
+      - name: "Cache dependencies"
+        uses: "actions/cache@v2"
+        with:
+          path: |
+            ~/.composer/cache
+            tools
+            vendor
+          key: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
+          restore-keys: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
+
+      - name: "Install lowest dependencies"
+        if: ${{ matrix.dependencies == 'lowest' }}
+        run: "composer update --prefer-lowest --no-interaction --no-progress --no-suggest"
+
+      - name: "Install highest dependencies"
+        if: ${{ matrix.dependencies == 'highest' }}
+        run: "composer update --no-interaction --no-progress --no-suggest"
+
+      - name: "Install locked dependencies"
+        if: ${{ matrix.dependencies == 'locked' }}
+        run: "composer install --no-interaction --no-progress --no-suggest"
+
+      - name: "Install tools"
+        run: "phive install --trust-gpg-keys E82B2FB314E9906E,4AA394086372C20A --force-accept-unsigned"
+
+      - name: "Test"
+        run: "composer test"

--- a/src/Aeon/Automation/Console/Command/ChangeLogGet.php
+++ b/src/Aeon/Automation/Console/Command/ChangeLogGet.php
@@ -8,13 +8,11 @@ use Aeon\Automation\ChangeLog;
 use Aeon\Automation\Console\AeonStyle;
 use Aeon\Automation\GitHub\Commit;
 use Aeon\Automation\GitHub\Commits;
-use Aeon\Automation\GitHub\PullRequest;
 use Aeon\Automation\GitHub\Reference;
 use Aeon\Automation\GitHub\Repository;
 use Aeon\Automation\GitHub\Tags;
 use Aeon\Calendar\Gregorian\DateTime;
 use Github\Exception\RuntimeException;
-use Github\HttpClient\Message\ResponseMediator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -137,18 +135,13 @@ final class ChangeLogGet extends AbstractCommand
             }
 
             if ($onlyPullRequests) {
-                $pullRequestsData = ResponseMediator::getContent(
-                    $this->github()->getHttpClient()->get(
-                        '/repos/' . \rawurlencode($project->organization()) . '/' . \rawurlencode($project->name()) . '/commits/' . \rawurlencode($commit->id()) . '/pulls',
-                        ['Accept' => 'application/vnd.github.groot-preview+json']
-                    )
-                );
+                $pullRequests = $commit->pullRequests($this->github(), $project);
 
-                if (!\count($pullRequestsData)) {
+                if (!$pullRequests->count()) {
                     continue;
                 }
 
-                $source = new PullRequest($pullRequestsData[0]);
+                $source = $pullRequests->first();
             }
 
             if (!$onlyPullRequests && !$onlyCommits) {

--- a/src/Aeon/Automation/Console/Command/ChangeLogGet.php
+++ b/src/Aeon/Automation/Console/Command/ChangeLogGet.php
@@ -6,6 +6,7 @@ namespace Aeon\Automation\Console\Command;
 
 use Aeon\Automation\ChangeLog;
 use Aeon\Automation\Console\AeonStyle;
+use Aeon\Automation\GitHub\Commit;
 use Aeon\Automation\GitHub\Commits;
 use Aeon\Automation\GitHub\PullRequest;
 use Aeon\Automation\GitHub\Reference;
@@ -38,6 +39,7 @@ final class ChangeLogGet extends AbstractCommand
             ->addOption('branch', 'b', InputOption::VALUE_REQUIRED, 'Get the the branch used instead of tag-start option when it\'s not provided. If empty, default repository branch is taken.')
             ->addOption('tag-start', 'ts', InputOption::VALUE_REQUIRED, 'Optional tag from which changelog generation starts. When not provided branch is used instead.')
             ->addOption('tag-end', 'te', InputOption::VALUE_REQUIRED, 'Optional tag until which changelog is generated. When not provided, latest tag is taken')
+            ->addOption('commit-end', 'ce', InputOption::VALUE_REQUIRED, 'Optional commit sha until which changelog is generated . When not provided, latest tag is taken')
             ->addOption('only-commits', 'oc', InputOption::VALUE_NONE, 'Use only commits to generate changelog')
             ->addOption('only-pull-requests', 'opr', InputOption::VALUE_NONE, 'Use only pull requests to generate changelog')
             ->addOption('changed-after', 'cb', InputOption::VALUE_REQUIRED, 'Ignore all changes after given date, relative date formats like "-1 day" are also supported')
@@ -67,15 +69,26 @@ final class ChangeLogGet extends AbstractCommand
         $io->note('Project: ' . $project->fullName());
         $io->note('From Reference: ' . $fromReferenceName);
         $io->note('Until Reference: ' . $untilReferenceName);
+        $io->note('Until Commit: ' . $input->getOption('commit-end'));
 
         try {
-            $untilReference = $untilReferenceName !== ''
-                ? Reference::commitFromString($this->github(), $project, $untilReferenceName)
+            $untilCommit = $untilReferenceName !== ''
+                ? Reference::commitFromString($this->github(), $project, $untilReferenceName)->commit($this->github(), $project)
                 : null;
         } catch (RuntimeException $e) {
             $io->error('Reference "tags/' . $input->getOption('tag-end') . '" does not exists: ' . $e->getMessage());
 
             return Command::FAILURE;
+        }
+
+        if ($input->getOption('commit-end')) {
+            try {
+                $untilCommit = Commit::fromSHA($this->github(), $project, $input->getOption('commit-end'));
+            } catch (RuntimeException $e) {
+                $io->error('Commit with SHA ' . $input->getOption('commit-end') . '" does not exists: ' . $e->getMessage());
+
+                return Command::FAILURE;
+            }
         }
 
         try {
@@ -87,7 +100,7 @@ final class ChangeLogGet extends AbstractCommand
         }
 
         try {
-            $fromReference = Reference::commitFromString($this->github(), $project, $fromReferenceName);
+            $fromCommit = Reference::commitFromString($this->github(), $project, $fromReferenceName)->commit($this->github(), $project);
         } catch (RuntimeException $e) {
             $io->error("Reference \"{$fromReferenceName}\" does not exists: " . $e->getMessage());
 
@@ -95,12 +108,12 @@ final class ChangeLogGet extends AbstractCommand
         }
 
         $io->note("Fetching all commits between \"{$fromReferenceName}\" and \"{$untilReferenceName}\"");
-        $commits = Commits::allFrom($this->github(), $project, $fromReference, $untilReference);
+        $commits = Commits::allFrom($this->github(), $project, $fromCommit, $untilCommit);
         $io->note('Total commits: ' . $commits->count());
 
         $io->progressStart($commits->count());
 
-        $changeLog = new ChangeLog($release, $fromReference->commit($this->github(), $project)->date()->day());
+        $changeLog = new ChangeLog($release, $fromCommit->date()->day());
 
         $onlyCommits = $input->getOption('only-commits');
         $onlyPullRequests = $input->getOption('only-pull-requests');
@@ -139,14 +152,9 @@ final class ChangeLogGet extends AbstractCommand
             }
 
             if (!$onlyPullRequests && !$onlyCommits) {
-                $pullRequestsData = ResponseMediator::getContent(
-                    $this->github()->getHttpClient()->get(
-                        '/repos/' . \rawurlencode($project->organization()) . '/' . \rawurlencode($project->name()) . '/commits/' . \rawurlencode($commit->id()) . '/pulls',
-                        ['Accept' => 'application/vnd.github.groot-preview+json']
-                    )
-                );
+                $pullRequests = $commit->pullRequests($this->github(), $project);
 
-                $source = \count($pullRequestsData) ? new PullRequest($pullRequestsData[0]) : $commit;
+                $source = $pullRequests->count() ? $pullRequests->first() : $commit;
             }
 
             $changeLog->add($source->changes());

--- a/src/Aeon/Automation/GitHub/Commits.php
+++ b/src/Aeon/Automation/GitHub/Commits.php
@@ -20,10 +20,10 @@ final class Commits
         $this->commits = $commits;
     }
 
-    public static function allFrom(Client $client, Project $project, Reference $fromReference, ?Reference $untilReference = null) : self
+    public static function allFrom(Client $client, Project $project, Commit $fromCommit, ?Commit $untilCommit = null) : self
     {
         $commitsPaginator = new ResultPager($client);
-        $commitsData = $commitsPaginator->fetch($client->api('repo')->commits(), 'all', [$project->organization(), $project->name(), ['sha' => $fromReference->sha()]]);
+        $commitsData = $commitsPaginator->fetch($client->repo()->commits(), 'all', [$project->organization(), $project->name(), ['sha' => $fromCommit]]);
 
         $foundAll = false;
 
@@ -34,7 +34,7 @@ final class Commits
             foreach ($commitsData as $commitData) {
                 $commit = new Commit($commitData);
 
-                if ($untilReference !== null && $commit->id() === $untilReference->sha()) {
+                if ($untilCommit !== null && $commit->sha() === $untilCommit->sha()) {
                     $foundAll = true;
 
                     break;

--- a/src/Aeon/Automation/GitHub/PullRequests.php
+++ b/src/Aeon/Automation/GitHub/PullRequests.php
@@ -48,6 +48,15 @@ final class PullRequests
         return \count($this->pullRequests);
     }
 
+    public function first() : ?PullRequest
+    {
+        if (!$this->count()) {
+            return null;
+        }
+
+        return \current($this->pullRequests);
+    }
+
     /**
      * @return PullRequest[]
      */

--- a/tests/Aeon/Automation/Tests/Integration/Console/Command/ChangeLogGetTest.php
+++ b/tests/Aeon/Automation/Tests/Integration/Console/Command/ChangeLogGetTest.php
@@ -27,7 +27,10 @@ final class ChangeLogGetTest extends CommandTestCase
                 GitHubResponseMother::repository('1.x')
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/1.0.0', ResponseMother::jsonSuccess(
-                GitHubResponseMother::refCommit('tags/1.0.0')
+                GitHubResponseMother::refCommit('tags/1.0.0', $tag100SHA = SHAMother::random())
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $tag100SHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Tag 1.0.0', $tag100SHA)
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/heads/1.x', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('heads/1.x', $headRefSHA = SHAMother::random())
@@ -88,11 +91,17 @@ final class ChangeLogGetTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/1.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/1.0.0', $refUntilSHA = SHAMother::random())
             )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refUntilSHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Tag 1.0.0', $refUntilSHA)
+            )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/heads/1.x', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('heads/1.x', $refHeadSHA = SHAMother::random())
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/2.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/2.0.0', $refFromSHA = SHAMother::random())
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Tag 2.0.0', $refFromSHA, '2020-01-01')
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits', ResponseMother::jsonSuccess(
                 [
@@ -155,11 +164,17 @@ final class ChangeLogGetTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/1.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/1.0.0', $refUntilSHA = SHAMother::random())
             )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refUntilSHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Tag 1.0.0', $refUntilSHA)
+            )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/heads/1.x', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('heads/1.x', $refHeadSHA = SHAMother::random())
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/2.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/2.0.0', $refFromSHA = SHAMother::random())
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Tag 2.0.0', $refFromSHA, '2020-01-01')
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits', ResponseMother::jsonSuccess(
                 [
@@ -223,11 +238,17 @@ final class ChangeLogGetTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/1.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/1.0.0', $refUntilSHA = SHAMother::random())
             )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refUntilSHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Tag 1.0.0', $refUntilSHA)
+            )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/heads/1.x', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('heads/1.x', $refHeadSHA = SHAMother::random())
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/2.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/2.0.0', $refFromSHA = SHAMother::random())
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Tag 2.0.0', $refFromSHA, '2020-01-01')
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits', ResponseMother::jsonSuccess(
                 [
@@ -291,11 +312,93 @@ final class ChangeLogGetTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/1.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/1.0.0', $refUntilSHA = SHAMother::random())
             )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refUntilSHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Tag 1.0.0', $refUntilSHA)
+            )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/heads/1.x', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('heads/1.x', $refHeadSHA = SHAMother::random())
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/2.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/2.0.0', $refFromSHA = SHAMother::random())
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Tag 2.0.0', $refFromSHA, '2020-01-01')
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits', ResponseMother::jsonSuccess(
+                [
+                    GitHubResponseMother::commit('Commit 1', $refFromSHA, '2020-01-10 00:00:00'),
+                    GitHubResponseMother::commit('Commit 2', $commit2SHA = SHAMother::random(), '2020-01-09 00:00:00'),
+                    GitHubResponseMother::commit('Commit 3', $refUntilSHA, '2020-01-08 00:00:00'),
+                    GitHubResponseMother::commit('Commit 4', $commit4SHA = SHAMother::random(), '2020-01-07 00:00:00'),
+                ]
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commitWithDate('Commit Message', '2020-01-01 00:00:00+00:00'),
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA . '/pulls', ResponseMother::jsonSuccess([])),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $commit2SHA . '/pulls', ResponseMother::jsonSuccess([GitHubResponseMother::pullRequest(2)])),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refUntilSHA . '/pulls', ResponseMother::jsonSuccess([])),
+        ));
+
+        $command = new ChangeLogGet();
+        $command->setGithub($client);
+        $application = new AeonApplication();
+        $application->add($command);
+
+        $commandTester = new CommandTester($application->get(ChangeLogGet::getDefaultName()));
+
+        $commandTester->setInputs(['verbosity' => ConsoleOutput::VERBOSITY_VERY_VERBOSE]);
+
+        $commandTester->execute(
+            [
+                'project' => 'aeon-php/automation',
+                '--tag-start' => '2.0.0',
+                '--changed-after' => '2020-01-07 12:00:00',
+            ],
+            ['verbosity' => ConsoleOutput::VERBOSITY_VERBOSE]
+        );
+
+        $this->assertStringContainsString('Change Log - Get', $commandTester->getDisplay());
+
+        $this->assertStringContainsString('[NOTE] Project: aeon-php/automation', $commandTester->getDisplay());
+        $this->assertStringContainsString('[NOTE] From Reference: tags/2.0.0', $commandTester->getDisplay());
+        $this->assertStringContainsString('[NOTE] Until Reference: ', $commandTester->getDisplay());
+        $this->assertStringContainsString('[NOTE] Fetching all commits between "tags/2.0.0" and ""', $commandTester->getDisplay());
+        $this->assertStringContainsString('[NOTE] Total commits: 4', $commandTester->getDisplay());
+
+        $this->assertStringContainsString('## 2.0.0 - 2020-01-01', $commandTester->getDisplay());
+        $this->assertStringContainsString('### Changed', $commandTester->getDisplay());
+        $this->assertStringContainsString(' - [' . \substr($refFromSHA, 0, 6) . '](http://api.github.com) - **Commit 1** - [@user_login](http//github.com/user_login)', $commandTester->getDisplay());
+        $this->assertStringContainsString(' - [#2](http://api.github.com) - **Pull Request Title** - [@user_login](http//github.com/user_login)', $commandTester->getDisplay());
+        $this->assertStringContainsString(' - [' . \substr($refUntilSHA, 0, 6) . '](http://api.github.com) - **Commit 3** - [@user_login](http//github.com/user_login)', $commandTester->getDisplay());
+        $this->assertStringNotContainsString('[' . \substr($commit4SHA, 0, 6) . '](http://api.github.com) - **Commit 4** - [@user_login](http//github.com/user_login)', $commandTester->getDisplay());
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function test_get_commit_end() : void
+    {
+        $client = Client::createWithHttpClient($httpClient = $this->httpClient(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/tags', ResponseMother::jsonSuccess([
+                GitHubResponseMother::tag('1.0.0'),
+            ])),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation', ResponseMother::jsonSuccess(
+                GitHubResponseMother::repository('1.x')
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/1.0.0', ResponseMother::jsonSuccess(
+                GitHubResponseMother::refCommit('tags/1.0.0', $refUntilSHA = SHAMother::random())
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refUntilSHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Tag 1.0.0', $refUntilSHA)
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/heads/1.x', ResponseMother::jsonSuccess(
+                GitHubResponseMother::refCommit('heads/1.x', $refHeadSHA = SHAMother::random())
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/2.0.0', ResponseMother::jsonSuccess(
+                GitHubResponseMother::refCommit('tags/2.0.0', $refFromSHA = SHAMother::random())
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Tag 2.0.0', $refFromSHA, '2020-01-01')
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits', ResponseMother::jsonSuccess(
                 [


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>`change-log:get --commit-end` flag that takes sha of a commit that should be the last in changelog</li>
    <li>Github tests workflow</li>
    <li>Dependabot configuration</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>the way to access pull requests related to the commit, those are now taken from the `Commit` object</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
