### PR TITLE
Added conventional commit support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           - "highest"
         php-version:
           - "7.4"
-          - "8.0"
+          #- "8.0"
         operating-system:
           - "ubuntu-latest"
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "php-http/logger-plugin": "^1.2",
         "monolog/monolog": "^2.2",
         "symfony/monolog-bridge": "^5.2",
-        "symfony/cache": "^5.2"
+        "symfony/cache": "^5.2",
+        "ramsey/conventional-commits": "^1.1"
     },
     "require-dev": {
         "coduo/php-matcher": "6.x@dev"
@@ -45,11 +46,11 @@
             "@test"
         ],
         "test": [
-            "tools\/phpunit.phar"
+            "tools/phpunit.phar"
         ],
         "static:analyze": [
-            "tools\/php-cs-fixer fix --dry-run"
+            "tools/php-cs-fixer fix --dry-run"
         ],
-        "cs:php:fix": "tools\/php-cs-fixer fix"
+        "cs:php:fix": "tools/php-cs-fixer fix"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff2dc56ffd0130e516629433942a3452",
+    "content-hash": "32982dd8d4d1ee6cde83b37cd64aac72",
     "packages": [
         {
             "name": "aeon-php/calendar",
@@ -60,6 +60,88 @@
                 }
             ],
             "time": "2020-12-21T23:15:02+00:00"
+        },
+        {
+            "name": "captainhook/captainhook",
+            "version": "5.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/captainhookphp/captainhook.git",
+                "reference": "c91b567364f20bc7c3d2db064cd59b4c4c731983"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/captainhookphp/captainhook/zipball/c91b567364f20bc7c3d2db064cd59b4c4c731983",
+                "reference": "c91b567364f20bc7c3d2db064cd59b4c4c731983",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-spl": "*",
+                "ext-xml": "*",
+                "php": ">=7.2",
+                "sebastianfeldmann/camino": "^0.9.2",
+                "sebastianfeldmann/cli": "^3.3",
+                "sebastianfeldmann/git": "^3.4",
+                "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0",
+                "symfony/process": "^2.7 || ^3.0 || ^4.0 || ^5.0"
+            },
+            "replace": {
+                "sebastianfeldmann/captainhook": "*"
+            },
+            "require-dev": {
+                "composer/composer": "~1",
+                "mikey179/vfsstream": "~1"
+            },
+            "bin": [
+                "bin/captainhook"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0.x-dev"
+                },
+                "captainhook": {
+                    "config": "captainhook.json"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "CaptainHook\\App\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Feldmann",
+                    "email": "sf@sebastian-feldmann.info"
+                }
+            ],
+            "description": "PHP git hook manager",
+            "homepage": "https://github.com/captainhookphp/captainhook",
+            "keywords": [
+                "commit-msg",
+                "git",
+                "hooks",
+                "post-merge",
+                "pre-commit",
+                "pre-push",
+                "prepare-commit-msg"
+            ],
+            "support": {
+                "issues": "https://github.com/captainhookphp/captainhook/issues",
+                "source": "https://github.com/captainhookphp/captainhook/tree/5.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/sebastianfeldmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-12-07T19:38:34+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -126,6 +208,178 @@
                 }
             ],
             "time": "2020-10-02T12:38:20+00:00"
+        },
+        {
+            "name": "composer/ca-bundle",
+            "version": "1.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/ca-bundle.git",
+                "reference": "8a7ecad675253e4654ea05505233285377405215"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/8a7ecad675253e4654ea05505233285377405215",
+                "reference": "8a7ecad675253e4654ea05505233285377405215",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8",
+                "psr/log": "^1.0",
+                "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\CaBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+            "keywords": [
+                "cabundle",
+                "cacert",
+                "certificate",
+                "ssl",
+                "tls"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/ca-bundle/issues",
+                "source": "https://github.com/composer/ca-bundle/tree/1.2.8"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-23T12:54:47+00:00"
+        },
+        {
+            "name": "composer/composer",
+            "version": "2.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/composer.git",
+                "reference": "62139b2806178adb979d76bd3437534a1a9fd490"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/composer/zipball/62139b2806178adb979d76bd3437534a1a9fd490",
+                "reference": "62139b2806178adb979d76bd3437534a1a9fd490",
+                "shasum": ""
+            },
+            "require": {
+                "composer/ca-bundle": "^1.0",
+                "composer/semver": "^3.0",
+                "composer/spdx-licenses": "^1.2",
+                "composer/xdebug-handler": "^1.1",
+                "justinrainbow/json-schema": "^5.2.10",
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0",
+                "react/promise": "^1.2 || ^2.7",
+                "seld/jsonlint": "^1.4",
+                "seld/phar-utils": "^1.0",
+                "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0",
+                "symfony/filesystem": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0",
+                "symfony/finder": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0",
+                "symfony/process": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0"
+            },
+            "require-dev": {
+                "phpspec/prophecy": "^1.10",
+                "symfony/phpunit-bridge": "^4.2 || ^5.0"
+            },
+            "suggest": {
+                "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",
+                "ext-zip": "Enabling the zip extension allows you to unzip archives",
+                "ext-zlib": "Allow gzip compression of HTTP requests"
+            },
+            "bin": [
+                "bin/composer"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\": "src/Composer"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "https://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Composer helps you declare, manage and install dependencies of PHP projects. It ensures you have the right stack everywhere.",
+            "homepage": "https://getcomposer.org/",
+            "keywords": [
+                "autoload",
+                "dependency",
+                "package"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/composer/issues",
+                "source": "https://github.com/composer/composer/tree/2.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-12-03T16:20:39+00:00"
         },
         {
             "name": "composer/semver",
@@ -207,6 +461,148 @@
                 }
             ],
             "time": "2020-11-13T08:59:24+00:00"
+        },
+        {
+            "name": "composer/spdx-licenses",
+            "version": "1.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/spdx-licenses.git",
+                "reference": "de30328a7af8680efdc03e396aad24befd513200"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/de30328a7af8680efdc03e396aad24befd513200",
+                "reference": "de30328a7af8680efdc03e396aad24befd513200",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Spdx\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "SPDX licenses list and validation library.",
+            "keywords": [
+                "license",
+                "spdx",
+                "validator"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/spdx-licenses/issues",
+                "source": "https://github.com/composer/spdx-licenses/tree/1.5.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-12-03T16:04:16+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "1.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/1.4.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T08:04:11+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -336,6 +732,138 @@
                 "source": "https://github.com/http-interop/http-factory-guzzle/tree/master"
             },
             "time": "2018-07-31T19:32:56+00:00"
+        },
+        {
+            "name": "jawira/case-converter",
+            "version": "v3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jawira/case-converter.git",
+                "reference": "756089a523ce268fb173a9f4af4ca95629b3a7f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jawira/case-converter/zipball/756089a523ce268fb173a9f4af4ca95629b3a7f0",
+                "reference": "756089a523ce268fb173a9f4af4ca95629b3a7f0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1"
+            },
+            "suggest": {
+                "pds/skeleton": "PHP Package Development Standards",
+                "phing/phing": "PHP Build Tool"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jawira\\CaseConverter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jawira Portugal",
+                    "email": "dev@tugal.be",
+                    "homepage": "http://jawira.com/"
+                }
+            ],
+            "description": "Convert strings between 13 naming conventions: Snake case, Camel case, Pascal case, Kebab case, Ada case, Train case, Cobol case, Macro case, Upper case, Lower case, Sentence case, Title case and Dot notation.",
+            "homepage": "https://jawira.github.io/case-converter/",
+            "keywords": [
+                "Ada case",
+                "Cobol case",
+                "Macro case",
+                "Train case",
+                "camel case",
+                "dot notation",
+                "kebab case",
+                "lower case",
+                "pascal case",
+                "sentence case",
+                "snake case",
+                "title case",
+                "upper case"
+            ],
+            "support": {
+                "issues": "https://github.com/jawira/case-converter/issues",
+                "source": "https://github.com/jawira/case-converter/tree/v3.4.1"
+            },
+            "time": "2019-12-15T14:31:43+00:00"
+        },
+        {
+            "name": "justinrainbow/json-schema",
+            "version": "5.2.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/justinrainbow/json-schema.git",
+                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
+                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
+                "json-schema/json-schema-test-suite": "1.2.0",
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/justinrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "support": {
+                "issues": "https://github.com/justinrainbow/json-schema/issues",
+                "source": "https://github.com/justinrainbow/json-schema/tree/5.2.10"
+            },
+            "time": "2020-05-27T16:41:55+00:00"
         },
         {
             "name": "knplabs/github-api",
@@ -518,6 +1046,73 @@
                 }
             ],
             "time": "2020-12-14T13:15:25+00:00"
+        },
+        {
+            "name": "opis/json-schema",
+            "version": "1.0.19",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/json-schema.git",
+                "reference": "1bcb3582881d0692d002537a4472964280f71313"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/json-schema/zipball/1bcb3582881d0692d002537a4472964280f71313",
+                "reference": "1bcb3582881d0692d002537a4472964280f71313",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ext-bcmath": "*",
+                "ext-intl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "opis/string": "^1.4",
+                "phpunit/phpunit": "^6.5 || ^7.0"
+            },
+            "suggest": {
+                "opis/string": "A standalone library for manipulating multibyte strings"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\JsonSchema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                },
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                }
+            ],
+            "description": "Json Schema Validator",
+            "homepage": "http://www.opis.io/json-schema",
+            "keywords": [
+                "json",
+                "schema",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/json-schema/issues",
+                "source": "https://github.com/opis/json-schema/tree/master"
+            },
+            "time": "2020-06-07T20:56:25+00:00"
         },
         {
             "name": "php-http/cache-plugin",
@@ -1497,6 +2092,427 @@
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
+            "name": "ramsey/conventional-commits",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/conventional-commits.git",
+                "reference": "3ff2644834456a8c67100178b775889cf5cf4a8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/conventional-commits/zipball/3ff2644834456a8c67100178b775889cf5cf4a8c",
+                "reference": "3ff2644834456a8c67100178b775889cf5cf4a8c",
+                "shasum": ""
+            },
+            "require": {
+                "captainhook/captainhook": "^5.3.3",
+                "composer-runtime-api": "^1.1 || ^2",
+                "composer/composer": "^1.1 || ^2.0",
+                "ext-json": "*",
+                "jawira/case-converter": "^3.3",
+                "opis/json-schema": "^1.0.8",
+                "php": "^7.4 || ^8",
+                "symfony/console": "^5.1.3",
+                "symfony/filesystem": "^5.1",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "require-dev": {
+                "ramsey/devtools": "^1.4",
+                "sebastianfeldmann/cli": "^3.3",
+                "sebastianfeldmann/git": "^3.3",
+                "spatie/phpunit-snapshot-assertions": "^4.2",
+                "symfony/process": "^5.1"
+            },
+            "bin": [
+                "bin/conventional-commits"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                },
+                "ramsey/conventional-commits": {
+                    "configFile": "conventional-commits.json"
+                },
+                "ramsey/devtools": {
+                    "command-prefix": "dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\CaptainHook\\": "src/CaptainHook/",
+                    "Ramsey\\ConventionalCommits\\": "src/ConventionalCommits/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                }
+            ],
+            "description": "A PHP library for creating and validating commit messages according to the Conventional Commits specification. Includes a CaptainHook plugin!",
+            "keywords": [
+                "HOOK",
+                "captainhook",
+                "commit",
+                "commit-msg",
+                "conventional",
+                "conventional-commits",
+                "git",
+                "plugin"
+            ],
+            "support": {
+                "issues": "https://github.com/ramsey/conventional-commits/issues",
+                "source": "https://github.com/ramsey/conventional-commits/tree/1.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ramsey",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T21:33:04+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/f3cff96a19736714524ca0dd1d4130de73dbbbc4",
+                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^6.5 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v2.8.0"
+            },
+            "time": "2020-05-12T15:16:56+00:00"
+        },
+        {
+            "name": "sebastianfeldmann/camino",
+            "version": "0.9.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianfeldmann/camino.git",
+                "reference": "3b611368e22e8565c3a6504613136402ed9e6f69"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianfeldmann/camino/zipball/3b611368e22e8565c3a6504613136402ed9e6f69",
+                "reference": "3b611368e22e8565c3a6504613136402ed9e6f69",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SebastianFeldmann\\Camino\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Feldmann",
+                    "email": "sf@sebastian-feldmann.info"
+                }
+            ],
+            "description": "Path management the OO way",
+            "homepage": "https://github.com/sebastianfeldmann/camino",
+            "keywords": [
+                "file system",
+                "path"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianfeldmann/camino/issues",
+                "source": "https://github.com/sebastianfeldmann/camino/tree/0.9.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianfeldmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-12-08T09:25:24+00:00"
+        },
+        {
+            "name": "sebastianfeldmann/cli",
+            "version": "3.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianfeldmann/cli.git",
+                "reference": "490a6ba01d62e56d597b4d3377024feb87871f6f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianfeldmann/cli/zipball/490a6ba01d62e56d597b4d3377024feb87871f6f",
+                "reference": "490a6ba01d62e56d597b4d3377024feb87871f6f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "symfony/process": "^4.3 | ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SebastianFeldmann\\Cli\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Feldmann",
+                    "email": "sf@sebastian-feldmann.info"
+                }
+            ],
+            "description": "PHP cli helper classes",
+            "homepage": "https://github.com/sebastianfeldmann/cli",
+            "keywords": [
+                "cli"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianfeldmann/cli/issues",
+                "source": "https://github.com/sebastianfeldmann/cli/tree/3.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianfeldmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-12-08T09:20:06+00:00"
+        },
+        {
+            "name": "sebastianfeldmann/git",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianfeldmann/git.git",
+                "reference": "a1855895dbc4056cb3f8d14645487f10a393c029"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianfeldmann/git/zipball/a1855895dbc4056cb3f8d14645487f10a393c029",
+                "reference": "a1855895dbc4056cb3f8d14645487f10a393c029",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-xml": "*",
+                "php": ">=7.2",
+                "sebastianfeldmann/cli": "^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SebastianFeldmann\\Git\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Feldmann",
+                    "email": "sf@sebastian-feldmann.info"
+                }
+            ],
+            "description": "PHP git wrapper",
+            "homepage": "https://github.com/sebastianfeldmann/git",
+            "keywords": [
+                "git"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianfeldmann/git/issues",
+                "source": "https://github.com/sebastianfeldmann/git/tree/3.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianfeldmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-12-08T09:38:31+00:00"
+        },
+        {
+            "name": "seld/jsonlint",
+            "version": "1.8.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
+                "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "bin": [
+                "bin/jsonlint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "JSON Linter",
+            "keywords": [
+                "json",
+                "linter",
+                "parser",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/jsonlint/issues",
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.8.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-11T09:19:24+00:00"
+        },
+        {
+            "name": "seld/phar-utils",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/phar-utils.git",
+                "reference": "8674b1d84ffb47cc59a101f5d5a3b61e87d23796"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/phar-utils/zipball/8674b1d84ffb47cc59a101f5d5a3b61e87d23796",
+                "reference": "8674b1d84ffb47cc59a101f5d5a3b61e87d23796",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Seld\\PharUtils\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "PHAR file format utilities, for when PHP phars you up",
+            "keywords": [
+                "phar"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/phar-utils/issues",
+                "source": "https://github.com/Seldaek/phar-utils/tree/master"
+            },
+            "time": "2020-07-07T18:42:57+00:00"
+        },
+        {
             "name": "symfony/cache",
             "version": "v5.2.1",
             "source": {
@@ -2205,6 +3221,129 @@
                 }
             ],
             "time": "2020-09-07T11:33:47+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v5.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "fa8f8cab6b65e2d99a118e082935344c5ba8c60d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/fa8f8cab6b65e2d99a118e082935344c5ba8c60d",
+                "reference": "fa8f8cab6b65e2d99a118e082935344c5ba8c60d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v5.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-30T17:05:38+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v5.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "0b9231a5922fd7287ba5b411893c0ecd2733e5ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/0b9231a5922fd7287ba5b411893c0ecd2733e5ba",
+                "reference": "0b9231a5922fd7287ba5b411893c0ecd2733e5ba",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v5.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-12-08T17:02:38+00:00"
         },
         {
             "name": "symfony/http-client",
@@ -3192,6 +4331,68 @@
                 }
             ],
             "time": "2020-10-23T14:02:19+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "bd8815b8b6705298beaa384f04fabd459c10bedd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/bd8815b8b6705298beaa384f04fabd459c10bedd",
+                "reference": "bd8815b8b6705298beaa384f04fabd459c10bedd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v5.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-12-08T17:03:37+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/src/Aeon/Automation/ChangeLog/MarkdownFormatter.php
+++ b/src/Aeon/Automation/ChangeLog/MarkdownFormatter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Aeon\Automation\ChangeLog;
 
 use Aeon\Automation\ChangeLog;
+use Aeon\Automation\Changes\Change;
 use Aeon\Automation\ChangesSource;
 use Aeon\Automation\GitHub\Commit;
 
@@ -80,13 +81,13 @@ final class MarkdownFormatter implements Formatter
         return $output;
     }
 
-    private function formatEntry(ChangesSource $source, string $entry) : string
+    private function formatEntry(ChangesSource $source, Change $change) : string
     {
         return \sprintf(
             " - [%s](%s) - **%s** - [@%s](%s)\n",
             ($source instanceof Commit) ? \substr($source->id(), 0, 6) : ('#' . $source->id()),
             $source->url(),
-            $entry,
+            $change->description(),
             $source->user(),
             $source->userUrl()
         );

--- a/src/Aeon/Automation/Changes.php
+++ b/src/Aeon/Automation/Changes.php
@@ -4,37 +4,40 @@ declare(strict_types=1);
 
 namespace Aeon\Automation;
 
+use Aeon\Automation\Changes\Change;
+use Aeon\Automation\Changes\Type;
+
 final class Changes
 {
     private ChangesSource $source;
 
     /**
-     * @var string[]
+     * @var Change[]
      */
     private array $added;
 
     /**
-     * @var string[]
+     * @var Change[]
      */
     private array $changed;
 
     /**
-     * @var string[]
+     * @var Change[]
      */
     private array $fixed;
 
     /**
-     * @var string[]
+     * @var Change[]
      */
     private array $removed;
 
     /**
-     * @var string[]
+     * @var Change[]
      */
     private array $deprecated;
 
     /**
-     * @var string[]
+     * @var Change[]
      */
     private array $security;
 
@@ -49,12 +52,12 @@ final class Changes
     public function __construct(ChangesSource $source, array $added, array $changed, array $fixed, array $removed, array $deprecated, array $security)
     {
         $this->source = $source;
-        $this->added = $added;
-        $this->changed = $changed;
-        $this->fixed = $fixed;
-        $this->removed = $removed;
-        $this->deprecated = $deprecated;
-        $this->security = $security;
+        $this->added = \array_map(fn (string $message) : Change => new Change(Type::added(), $message), $added);
+        $this->changed = \array_map(fn (string $message) : Change => new Change(Type::changed(), $message), $changed);
+        $this->fixed = \array_map(fn (string $message) : Change => new Change(Type::fixed(), $message), $fixed);
+        $this->removed = \array_map(fn (string $message) : Change => new Change(Type::removed(), $message), $removed);
+        $this->deprecated = \array_map(fn (string $message) : Change => new Change(Type::deprecated(), $message), $deprecated);
+        $this->security = \array_map(fn (string $message) : Change => new Change(Type::security(), $message), $security);
     }
 
     public function empty() : bool
@@ -68,7 +71,7 @@ final class Changes
     }
 
     /**
-     * @return string[]
+     * @return Change[]
      */
     public function added() : array
     {
@@ -76,7 +79,7 @@ final class Changes
     }
 
     /**
-     * @return string[]
+     * @return Change[]
      */
     public function changed() : array
     {
@@ -84,7 +87,7 @@ final class Changes
     }
 
     /**
-     * @return string[]
+     * @return Change[]
      */
     public function fixed() : array
     {
@@ -92,7 +95,7 @@ final class Changes
     }
 
     /**
-     * @return string[]
+     * @return Change[]
      */
     public function removed() : array
     {
@@ -100,7 +103,7 @@ final class Changes
     }
 
     /**
-     * @return string[]
+     * @return Change[]
      */
     public function deprecated() : array
     {
@@ -108,22 +111,25 @@ final class Changes
     }
 
     /**
-     * @return string[]
+     * @return Change[]
      */
     public function security() : array
     {
         return $this->security;
     }
 
-    public function merge(self $changeLog) : self
+    /**
+     * @return Change[]
+     */
+    public function all() : array
     {
-        return new self(
-            \array_merge($this->added, $changeLog->added()),
-            \array_merge($this->changed, $changeLog->changed()),
-            \array_merge($this->fixed, $changeLog->fixed()),
-            \array_merge($this->removed, $changeLog->removed()),
-            \array_merge($this->deprecated, $changeLog->deprecated()),
-            \array_merge($this->security, $changeLog->security())
+        return \array_merge(
+            $this->added(),
+            $this->changed(),
+            $this->fixed(),
+            $this->removed(),
+            $this->deprecated(),
+            $this->security()
         );
     }
 }

--- a/src/Aeon/Automation/Changes/Change.php
+++ b/src/Aeon/Automation/Changes/Change.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Automation\Changes;
+
+final class Change
+{
+    private Type $type;
+
+    private string $description;
+
+    public function __construct(Type $type, string $description)
+    {
+        $this->type = $type;
+        $this->description = $description;
+    }
+
+    public function type() : Type
+    {
+        return $this->type;
+    }
+
+    public function description() : string
+    {
+        return $this->description;
+    }
+}

--- a/src/Aeon/Automation/Changes/ChangesParser.php
+++ b/src/Aeon/Automation/Changes/ChangesParser.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Aeon\Automation\Changes;
+
+use Aeon\Automation\Changes;
+use Aeon\Automation\ChangesSource;
+
+interface ChangesParser
+{
+    public function support(ChangesSource $changesSource) : bool;
+
+    public function parse(ChangesSource $changesSource) : Changes;
+}

--- a/src/Aeon/Automation/Changes/ChangesParser/ConventionalCommitParser.php
+++ b/src/Aeon/Automation/Changes/ChangesParser/ConventionalCommitParser.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Automation\Changes\ChangesParser;
+
+use Aeon\Automation\Changes;
+use Aeon\Automation\Changes\ChangesParser;
+use Aeon\Automation\ChangesSource;
+use Ramsey\ConventionalCommits\Configuration\DefaultConfiguration;
+use Ramsey\ConventionalCommits\Exception\InvalidCommitMessage;
+use Ramsey\ConventionalCommits\Parser;
+
+final class ConventionalCommitParser implements ChangesParser
+{
+    private const DEFAULT_TYPES = [
+        'add', 'added', 'feat', 'fix', 'fixed', 'cs', 'remove', 'removed', 'rm',
+        'dep', 'deprecated', 'deprecate', 'sec', 'security',
+        'change', 'changed', 'updated',
+    ];
+
+    public function support(ChangesSource $changesSource) : bool
+    {
+        try {
+            $parser = new Parser(new DefaultConfiguration([
+                'types' => self::DEFAULT_TYPES,
+            ]));
+
+            $message = $parser->parse($changesSource->description());
+
+            return $message->getType() !== null && $message->getDescription() !== null;
+        } catch (\Exception $invalidCommitMessage) {
+            return false;
+        }
+    }
+
+    public function parse(ChangesSource $changesSource) : Changes
+    {
+        $parser = new Parser(new DefaultConfiguration([
+            'types' => self::DEFAULT_TYPES,
+        ]));
+
+        $message = $parser->parse($changesSource->description());
+
+        switch (\strtolower($message->getType()->toString())) {
+            case 'add':
+            case 'added':
+            case 'feat':
+                return new Changes(
+                    $changesSource,
+                    [$message->getDescription()->toString()],
+                    [],
+                    [],
+                    [],
+                    [],
+                    []
+                );
+            case 'cs':
+            case 'fixed':
+            case 'fix':
+                return new Changes(
+                    $changesSource,
+                    [],
+                    [],
+                    [$message->getDescription()->toString()],
+                    [],
+                    [],
+                    []
+                );
+            case 'removed':
+            case 'rm':
+            case 'remove':
+                return new Changes(
+                    $changesSource,
+                    [],
+                    [],
+                    [],
+                    [$message->getDescription()->toString()],
+                    [],
+                    []
+                );
+            case 'dep':
+            case 'deprecated':
+            case 'deprecate':
+                return new Changes(
+                    $changesSource,
+                    [],
+                    [],
+                    [],
+                    [],
+                    [$message->getDescription()->toString()],
+                    []
+                );
+            case 'sec':
+            case 'security':
+                return new Changes(
+                    $changesSource,
+                    [],
+                    [],
+                    [],
+                    [],
+                    [],
+                    [$message->getDescription()->toString()]
+                );
+            case 'updated':
+            case 'changed':
+            case 'change':
+                return new Changes(
+                    $changesSource,
+                    [],
+                    [$message->getDescription()->toString()],
+                    [],
+                    [],
+                    [],
+                    []
+                );
+
+            default:
+                throw new InvalidCommitMessage('Invalid format: ' . $changesSource->description());
+        }
+    }
+}

--- a/src/Aeon/Automation/Changes/ChangesParser/DefaultParser.php
+++ b/src/Aeon/Automation/Changes/ChangesParser/DefaultParser.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Automation\Changes\ChangesParser;
+
+use Aeon\Automation\Changes;
+use Aeon\Automation\Changes\ChangesParser;
+use Aeon\Automation\ChangesSource;
+
+final class DefaultParser implements ChangesParser
+{
+    public function support(ChangesSource $changesSource) : bool
+    {
+        return true;
+    }
+
+    public function parse(ChangesSource $changesSource) : Changes
+    {
+        return new Changes(
+            $changesSource,
+            [],
+            [$changesSource->title()],
+            [],
+            [],
+            [],
+            []
+        );
+    }
+}

--- a/src/Aeon/Automation/Changes/ChangesParser/HTMLChangesParser.php
+++ b/src/Aeon/Automation/Changes/ChangesParser/HTMLChangesParser.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Automation\Changes\ChangesParser;
+
+use Aeon\Automation\Changes;
+use Aeon\Automation\Changes\ChangesParser;
+use Aeon\Automation\ChangesSource;
+use Symfony\Component\DomCrawler\Crawler;
+
+final class HTMLChangesParser implements ChangesParser
+{
+    public function support(ChangesSource $changesSource) : bool
+    {
+        if (\strip_tags($changesSource->description()) === $changesSource->description()) {
+            return false;
+        }
+
+        $crawler = new Crawler('<html><body><div id="changes">' . $changesSource->description() . '</div></body></html>');
+
+        if (!$crawler->filter('#change-log')->count()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function parse(ChangesSource $changesSource) : Changes
+    {
+        $crawler = new Crawler('<html><body><div id="changes">' . $changesSource->description() . '</div></body></html>');
+
+        if (!$crawler->filter('#change-log')->count()) {
+            return new Changes($changesSource, [], [$changesSource->title()], [], [], [], []);
+        }
+
+        $added = [];
+
+        if ($crawler->filter('ul#added')->count()) {
+            foreach ($crawler->filter('ul#added')->children('li') as $node) {
+                $added[] = $node->textContent;
+            }
+        }
+
+        $changed = [];
+
+        if ($crawler->filter('ul#changed')->count()) {
+            foreach ($crawler->filter('ul#changed')->children('li') as $node) {
+                $changed[] = $node->textContent;
+            }
+        }
+
+        $fixed = [];
+
+        if ($crawler->filter('ul#fixed')->count()) {
+            foreach ($crawler->filter('ul#fixed')->children('li') as $node) {
+                $fixed[] = $node->textContent;
+            }
+        }
+
+        $removed = [];
+
+        if ($crawler->filter('ul#removed')->count()) {
+            foreach ($crawler->filter('ul#removed')->children('li') as $node) {
+                $removed[] = $node->textContent;
+            }
+        }
+
+        $deprecated = [];
+
+        if ($crawler->filter('ul#deprecated')->count()) {
+            foreach ($crawler->filter('ul#deprecated')->children('li') as $node) {
+                $deprecated[] = $node->textContent;
+            }
+        }
+
+        $security = [];
+
+        if ($crawler->filter('ul#security')->count()) {
+            foreach ($crawler->filter('ul#security')->children('li') as $node) {
+                $security[] = $node->textContent;
+            }
+        }
+
+        return new Changes($changesSource, $added, $changed, $fixed, $removed, $deprecated, $security);
+    }
+}

--- a/src/Aeon/Automation/Changes/ChangesParser/PrioritizedParser.php
+++ b/src/Aeon/Automation/Changes/ChangesParser/PrioritizedParser.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Automation\Changes\ChangesParser;
+
+use Aeon\Automation\Changes;
+use Aeon\Automation\Changes\ChangesParser;
+use Aeon\Automation\ChangesSource;
+
+final class PrioritizedParser implements ChangesParser
+{
+    /**
+     * @var ChangesParser[]
+     */
+    private array $parsers;
+
+    public function __construct(ChangesParser ...$parsers)
+    {
+        $this->parsers = $parsers;
+    }
+
+    public function support(ChangesSource $changesSource) : bool
+    {
+        foreach ($this->parsers as $parser) {
+            if ($parser->support($changesSource)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function parse(ChangesSource $changesSource) : Changes
+    {
+        foreach ($this->parsers as $parser) {
+            if ($parser->support($changesSource)) {
+                return $parser->parse($changesSource);
+            }
+        }
+
+        throw new \RuntimeException('There is no parser that supports given changes source');
+    }
+}

--- a/src/Aeon/Automation/Changes/Type.php
+++ b/src/Aeon/Automation/Changes/Type.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Automation\Changes;
+
+final class Type
+{
+    private const TYPE_ADDED = 1;
+
+    private const TYPE_CHANGED = 2;
+
+    private const TYPE_FIXED = 3;
+
+    private const TYPE_REMOVED = 4;
+
+    private const TYPE_DEPRECATED = 5;
+
+    private const TYPE_SECURITY = 6;
+
+    private int $type;
+
+    private function __construct(int $type)
+    {
+        $this->type = $type;
+    }
+
+    public static function added() : self
+    {
+        return new self(self::TYPE_ADDED);
+    }
+
+    public static function changed() : self
+    {
+        return new self(self::TYPE_CHANGED);
+    }
+
+    public static function fixed() : self
+    {
+        return new self(self::TYPE_FIXED);
+    }
+
+    public static function removed() : self
+    {
+        return new self(self::TYPE_REMOVED);
+    }
+
+    public static function deprecated() : self
+    {
+        return new self(self::TYPE_DEPRECATED);
+    }
+
+    public static function security() : self
+    {
+        return new self(self::TYPE_SECURITY);
+    }
+}

--- a/src/Aeon/Automation/Changes/TypeParser.php
+++ b/src/Aeon/Automation/Changes/TypeParser.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Automation\Changes;
+
+interface TypeParser
+{
+    public function parse(string $message) : Change;
+}

--- a/src/Aeon/Automation/ChangesSource.php
+++ b/src/Aeon/Automation/ChangesSource.php
@@ -10,11 +10,11 @@ interface ChangesSource
 
     public function title() : string;
 
+    public function description() : string;
+
     public function user() : string;
 
     public function userUrl() : string;
-
-    public function changes() : Changes;
 
     public function equals(self $source) : bool;
 }

--- a/src/Aeon/Automation/Console/Command/PullRequestsList.php
+++ b/src/Aeon/Automation/Console/Command/PullRequestsList.php
@@ -65,7 +65,7 @@ final class PullRequestsList extends AbstractCommand
             : PullRequests::allClosedFor($this->github(), $project, $branchName, (int) $input->getOption('limit'))->onlyMerged();
 
         foreach ($pullRequests->all() as $pullRequest) {
-            $pullRequestOutput = '#' . $pullRequest->id() . ' - ' . $pullRequest->title();
+            $pullRequestOutput = '#' . $pullRequest->id() . ' - ' . $pullRequest->description();
 
             if ($input->getOption('check-milestone')) {
                 if (!$pullRequest->hasMilestone()) {

--- a/src/Aeon/Automation/GitHub/PullRequest.php
+++ b/src/Aeon/Automation/GitHub/PullRequest.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Aeon\Automation\GitHub;
 
-use Aeon\Automation\Changes;
 use Aeon\Automation\ChangesSource;
-use Symfony\Component\DomCrawler\Crawler;
 
 final class PullRequest implements ChangesSource
 {
@@ -18,6 +16,11 @@ final class PullRequest implements ChangesSource
     }
 
     public function id() : string
+    {
+        return $this->number();
+    }
+
+    public function number() : string
     {
         return (string) $this->data['number'];
     }
@@ -32,6 +35,11 @@ final class PullRequest implements ChangesSource
         return $this->data['title'];
     }
 
+    public function description() : string
+    {
+        return $this->data['body'] ?? $this->data['title'];
+    }
+
     public function user() : string
     {
         return $this->data['user']['login'];
@@ -40,85 +48,6 @@ final class PullRequest implements ChangesSource
     public function userUrl() : string
     {
         return $this->data['user']['html_url'];
-    }
-
-    public function haveHTML() : bool
-    {
-        if (!isset($this->data['body'])) {
-            return false;
-        }
-
-        return \strip_tags($this->data['body']) !== $this->data['body'];
-    }
-
-    public function haveChangesDescription() : bool
-    {
-        $crawler = $this->crawler();
-
-        return (bool) $crawler->filter('#change-log')->count();
-    }
-
-    public function changes() : Changes
-    {
-        if (!$this->haveHTML()) {
-            return new Changes($this, [], [$this->title()], [], [], [], []);
-        }
-
-        $crawler = $this->crawler();
-
-        if (!$crawler->filter('#change-log')->count()) {
-            return new Changes($this, [], [$this->title()], [], [], [], []);
-        }
-
-        $added = [];
-
-        if ($crawler->filter('ul#added')->count()) {
-            foreach ($crawler->filter('ul#added')->children('li') as $node) {
-                $added[] = $node->textContent;
-            }
-        }
-
-        $changed = [];
-
-        if ($crawler->filter('ul#changed')->count()) {
-            foreach ($crawler->filter('ul#changed')->children('li') as $node) {
-                $changed[] = $node->textContent;
-            }
-        }
-
-        $fixed = [];
-
-        if ($crawler->filter('ul#fixed')->count()) {
-            foreach ($crawler->filter('ul#fixed')->children('li') as $node) {
-                $fixed[] = $node->textContent;
-            }
-        }
-
-        $removed = [];
-
-        if ($crawler->filter('ul#removed')->count()) {
-            foreach ($crawler->filter('ul#removed')->children('li') as $node) {
-                $removed[] = $node->textContent;
-            }
-        }
-
-        $deprecated = [];
-
-        if ($crawler->filter('ul#deprecated')->count()) {
-            foreach ($crawler->filter('ul#deprecated')->children('li') as $node) {
-                $deprecated[] = $node->textContent;
-            }
-        }
-
-        $security = [];
-
-        if ($crawler->filter('ul#security')->count()) {
-            foreach ($crawler->filter('ul#security')->children('li') as $node) {
-                $security[] = $node->textContent;
-            }
-        }
-
-        return new Changes($this, $added, $changed, $fixed, $removed, $deprecated, $security);
     }
 
     public function isMerged() : bool
@@ -134,17 +63,5 @@ final class PullRequest implements ChangesSource
     public function equals(ChangesSource $source) : bool
     {
         return $source->id() === $this->id();
-    }
-
-    /**
-     * @return Crawler
-     */
-    private function crawler() : Crawler
-    {
-        if (!isset($this->data['body'])) {
-            return new Crawler('<html><body></body></html>');
-        }
-
-        return new Crawler('<html><body><div id="pull-request-body">' . $this->data['body'] . '</div></body></html>');
     }
 }

--- a/src/Aeon/Automation/GitHub/Reference.php
+++ b/src/Aeon/Automation/GitHub/Reference.php
@@ -48,6 +48,6 @@ final class Reference
             throw new \RuntimeException('Reference is not a commit');
         }
 
-        return new Commit($client->gitData()->commits()->show($project->organization(), $project->name(), $this->sha()));
+        return new Commit($client->repo()->commits()->show($project->organization(), $project->name(), $this->sha()));
     }
 }

--- a/src/Aeon/Automation/Project.php
+++ b/src/Aeon/Automation/Project.php
@@ -10,6 +10,10 @@ final class Project
 
     public function __construct(string $name)
     {
+        if (\strpos($name, '/') === false) {
+            throw new \InvalidArgumentException('Project name must be provided in given format: "organization/name"');
+        }
+
         $this->name = $name;
     }
 

--- a/tests/Aeon/Automation/Tests/Integration/Console/Command/ChangeLogGetTest.php
+++ b/tests/Aeon/Automation/Tests/Integration/Console/Command/ChangeLogGetTest.php
@@ -21,15 +21,15 @@ final class ChangeLogGetTest extends CommandTestCase
     {
         $client = Client::createWithHttpClient($httpClient = $this->httpClient(
             new HttpRequestStub('GET', '/repos/aeon-php/automation/tags', ResponseMother::jsonSuccess([
-                GitHubResponseMother::tag('1.0.0'),
+                GitHubResponseMother::tag('1.0.0', $tag100SHA = SHAMother::random()),
             ])),
             new HttpRequestStub('GET', '/repos/aeon-php/automation', ResponseMother::jsonSuccess(
                 GitHubResponseMother::repository('1.x')
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/1.0.0', ResponseMother::jsonSuccess(
-                GitHubResponseMother::refCommit('tags/1.0.0', $tag100SHA = SHAMother::random())
+                GitHubResponseMother::refCommit('tags/1.0.0', $tag100SHA)
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $tag100SHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $tag100SHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commit('Tag 1.0.0', $tag100SHA)
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/heads/1.x', ResponseMother::jsonSuccess(
@@ -38,7 +38,7 @@ final class ChangeLogGetTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits', ResponseMother::jsonSuccess(
                 [GitHubResponseMother::commit('Commit 1', $commit1SHA = SHAMother::random()), GitHubResponseMother::commit('Commit 2', $commit2SHA = SHAMother::random())]
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $headRefSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $headRefSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commitWithDate('Commit Message', '2020-01-01 00:00:00+00:00'),
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $commit1SHA . '/pulls', ResponseMother::jsonSuccess(
@@ -91,7 +91,7 @@ final class ChangeLogGetTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/1.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/1.0.0', $refUntilSHA = SHAMother::random())
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refUntilSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refUntilSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commit('Tag 1.0.0', $refUntilSHA)
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/heads/1.x', ResponseMother::jsonSuccess(
@@ -100,7 +100,7 @@ final class ChangeLogGetTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/2.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/2.0.0', $refFromSHA = SHAMother::random())
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commit('Tag 2.0.0', $refFromSHA, '2020-01-01')
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits', ResponseMother::jsonSuccess(
@@ -111,7 +111,7 @@ final class ChangeLogGetTest extends CommandTestCase
                     GitHubResponseMother::commit('Commit 4', $commit4SHA = SHAMother::random()),
                 ]
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commitWithDate('Commit Message', '2020-01-01 00:00:00+00:00'),
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA . '/pulls', ResponseMother::jsonSuccess([])),
@@ -164,7 +164,7 @@ final class ChangeLogGetTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/1.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/1.0.0', $refUntilSHA = SHAMother::random())
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refUntilSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refUntilSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commit('Tag 1.0.0', $refUntilSHA)
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/heads/1.x', ResponseMother::jsonSuccess(
@@ -173,7 +173,7 @@ final class ChangeLogGetTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/2.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/2.0.0', $refFromSHA = SHAMother::random())
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commit('Tag 2.0.0', $refFromSHA, '2020-01-01')
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits', ResponseMother::jsonSuccess(
@@ -184,7 +184,7 @@ final class ChangeLogGetTest extends CommandTestCase
                     GitHubResponseMother::commit('Commit 4', $commit4SHA = SHAMother::random()),
                 ]
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commitWithDate('Commit Message', '2020-01-01 00:00:00+00:00'),
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA . '/pulls', ResponseMother::jsonSuccess([GitHubResponseMother::pullRequest(1)])),
@@ -238,7 +238,7 @@ final class ChangeLogGetTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/1.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/1.0.0', $refUntilSHA = SHAMother::random())
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refUntilSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refUntilSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commit('Tag 1.0.0', $refUntilSHA)
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/heads/1.x', ResponseMother::jsonSuccess(
@@ -247,7 +247,7 @@ final class ChangeLogGetTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/2.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/2.0.0', $refFromSHA = SHAMother::random())
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commit('Tag 2.0.0', $refFromSHA, '2020-01-01')
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits', ResponseMother::jsonSuccess(
@@ -258,7 +258,7 @@ final class ChangeLogGetTest extends CommandTestCase
                     GitHubResponseMother::commit('Commit 4', $commit4SHA = SHAMother::random()),
                 ]
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commitWithDate('Commit Message', '2020-01-01 00:00:00+00:00'),
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA . '/pulls', ResponseMother::jsonSuccess([])),
@@ -312,7 +312,7 @@ final class ChangeLogGetTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/1.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/1.0.0', $refUntilSHA = SHAMother::random())
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refUntilSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refUntilSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commit('Tag 1.0.0', $refUntilSHA)
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/heads/1.x', ResponseMother::jsonSuccess(
@@ -321,7 +321,7 @@ final class ChangeLogGetTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/2.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/2.0.0', $refFromSHA = SHAMother::random())
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commit('Tag 2.0.0', $refFromSHA, '2020-01-01')
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits', ResponseMother::jsonSuccess(
@@ -332,7 +332,7 @@ final class ChangeLogGetTest extends CommandTestCase
                     GitHubResponseMother::commit('Commit 4', $commit4SHA = SHAMother::random(), '2020-01-07 00:00:00'),
                 ]
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commitWithDate('Commit Message', '2020-01-01 00:00:00+00:00'),
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA . '/pulls', ResponseMother::jsonSuccess([])),
@@ -388,7 +388,7 @@ final class ChangeLogGetTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/1.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/1.0.0', $refUntilSHA = SHAMother::random())
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refUntilSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refUntilSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commit('Tag 1.0.0', $refUntilSHA)
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/heads/1.x', ResponseMother::jsonSuccess(
@@ -397,7 +397,7 @@ final class ChangeLogGetTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/2.0.0', ResponseMother::jsonSuccess(
                 GitHubResponseMother::refCommit('tags/2.0.0', $refFromSHA = SHAMother::random())
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commit('Tag 2.0.0', $refFromSHA, '2020-01-01')
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits', ResponseMother::jsonSuccess(
@@ -408,7 +408,7 @@ final class ChangeLogGetTest extends CommandTestCase
                     GitHubResponseMother::commit('Commit 4', $commit4SHA = SHAMother::random(), '2020-01-07 00:00:00'),
                 ]
             )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA, ResponseMother::jsonSuccess(
                 GitHubResponseMother::commitWithDate('Commit Message', '2020-01-01 00:00:00+00:00'),
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $refFromSHA . '/pulls', ResponseMother::jsonSuccess([])),

--- a/tests/Aeon/Automation/Tests/Mother/ChangesSourceMother.php
+++ b/tests/Aeon/Automation/Tests/Mother/ChangesSourceMother.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Automation\Tests\Mother;
+
+use Aeon\Automation\ChangesSource;
+
+final class ChangesSourceMother
+{
+    public static function withContent(string $content) : ChangesSource
+    {
+        return new class($content) implements ChangesSource {
+            private string $content;
+
+            public function __construct(string $content)
+            {
+                $this->content = $content;
+            }
+
+            public function id() : string
+            {
+                throw new \RuntimeException('not implemented');
+            }
+
+            public function url() : string
+            {
+                throw new \RuntimeException('not implemented');
+            }
+
+            public function description() : string
+            {
+                return $this->content;
+            }
+
+            public function user() : string
+            {
+                throw new \RuntimeException('not implemented');
+            }
+
+            public function userUrl() : string
+            {
+                throw new \RuntimeException('not implemented');
+            }
+
+            public function equals(ChangesSource $source) : bool
+            {
+                throw new \RuntimeException('not implemented');
+            }
+        };
+    }
+}

--- a/tests/Aeon/Automation/Tests/Mother/GitHubResponseMother.php
+++ b/tests/Aeon/Automation/Tests/Mother/GitHubResponseMother.php
@@ -45,10 +45,16 @@ final class GitHubResponseMother
             'sha' => $sha ? $sha : SHAMother::random(),
             'html_url' => 'http://api.github.com',
             'message' => $message,
+            'commit' => [
+                'author' => [
+                    'email' => 'author@email.com',
+                    'date' => $date ? $date : GregorianCalendar::UTC()->now()->toISO8601(),
+                ],
+                'message' => $message,
+            ],
             'author' => [
                 'login' => 'user_login',
                 'html_url' => 'http//github.com/user_login',
-                'date' => $date ? $date : GregorianCalendar::UTC()->now()->toISO8601(),
             ],
         ];
     }
@@ -59,10 +65,16 @@ final class GitHubResponseMother
             'sha' => SHAMother::random(),
             'html_url' => 'http://api.github.com',
             'message' => $message,
+            'commit' => [
+                'author' => [
+                    'email' => 'author@email.com',
+                    'date' => $date ? $date : GregorianCalendar::UTC()->now()->toISO8601(),
+                ],
+                'message' => $message,
+            ],
             'author' => [
                 'login' => 'user_login',
                 'html_url' => 'http//github.com/user_login',
-                'date' => $date,
             ],
         ];
     }

--- a/tests/Aeon/Automation/Tests/Unit/Changes/ChangesParser/ConventionalParserTest.php
+++ b/tests/Aeon/Automation/Tests/Unit/Changes/ChangesParser/ConventionalParserTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Automation\Tests\Unit\Changes\ChangesParser;
+
+use Aeon\Automation\Changes\Change;
+use Aeon\Automation\Changes\ChangesParser\ConventionalCommitParser;
+use Aeon\Automation\Changes\Type;
+use Aeon\Automation\Tests\Mother\ChangesSourceMother;
+use PHPUnit\Framework\TestCase;
+
+final class ConventionalParserTest extends TestCase
+{
+    /**
+     * @dataProvider valid_conventional_commit_messages
+     */
+    public function test_valid_conventional_commit_messages(string $message, array $expectedChanges) : void
+    {
+        $this->assertEquals($expectedChanges, (new ConventionalCommitParser())->parse(ChangesSourceMother::withContent($message))->all());
+    }
+
+    public function valid_conventional_commit_messages() : \Generator
+    {
+        yield ['fix: fixed something', [new Change(Type::fixed(), 'fixed something')]];
+        yield ['add: added something', [new Change(Type::added(), 'added something')]];
+        yield ['AddeD: added something', [new Change(Type::added(), 'added something')]];
+        yield ['rm: removed something', [new Change(Type::removed(), 'removed something')]];
+    }
+}

--- a/tests/Aeon/Automation/Tests/Unit/Changes/ChangesParser/HTMLChangesParserTest.php
+++ b/tests/Aeon/Automation/Tests/Unit/Changes/ChangesParser/HTMLChangesParserTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Automation\Tests\Unit\Changes\ChangesParser;
+
+use Aeon\Automation\Changes;
+use Aeon\Automation\Changes\ChangesParser\HTMLChangesParser;
+use Aeon\Automation\Tests\Mother\ChangesSourceMother;
+use PHPUnit\Framework\TestCase;
+
+final class HTMLChangesParserTest extends TestCase
+{
+    public function test_support_for_not_valid_html() : void
+    {
+        $this->assertFalse((new HTMLChangesParser())->support(ChangesSourceMother::withContent('not valid html')));
+    }
+
+    public function test_support_for_html_changes_with_invalid_format() : void
+    {
+        $this->assertFalse((new HTMLChangesParser())->support(ChangesSourceMother::withContent('<p>not valid html<p/>')));
+    }
+
+    public function test_support_valid_html_format() : void
+    {
+        $content = <<<'HTML'
+<div id="change-log">
+    <ul id="added">
+        <li>added</li>
+        </ul>
+    <ul id="changed">
+        <li>changed</li>
+        </ul>
+    <ul id="fixed">
+        <li>fixed</li>
+        </ul>
+    <ul id="removed">
+        <li>removed</li>
+    </ul>
+    <ul id="deprecated">
+        <li>deprecated</li>
+    </ul>
+    <ul id="security">
+        <li>security</li>
+    </ul>
+</div>
+HTML;
+
+        $changes = (new HTMLChangesParser())->parse(ChangesSourceMother::withContent($content));
+
+        $this->assertEquals([new Changes\Change(Changes\Type::added(), 'added')], $changes->added());
+        $this->assertEquals([new Changes\Change(Changes\Type::changed(), 'changed')], $changes->changed());
+        $this->assertEquals([new Changes\Change(Changes\Type::fixed(), 'fixed')], $changes->fixed());
+        $this->assertEquals([new Changes\Change(Changes\Type::removed(), 'removed')], $changes->removed());
+        $this->assertEquals([new Changes\Change(Changes\Type::deprecated(), 'deprecated')], $changes->deprecated());
+        $this->assertEquals([new Changes\Change(Changes\Type::security(), 'security')], $changes->security());
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>support for conventional commit format</li>
    <li>Change object that holds Type and description</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>use Repository commit data instead of GitData to make sure commit author login is always available</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>changes are now parsed by ChangesParser object, not directly in PullRequest/Commit</li>
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>test suite execution at php8 due to lack of php8 support of one dependency</li>
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
