### PR TITLE
Added Prefix Parser to detect change types by prefixes

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,9 +15,9 @@
   </coverage>
   <logging/>
   <testsuites>
-<!--    <testsuite name="unit">-->
-<!--      <directory suffix=".php">tests/Aeon/Automation/Tests/Unit</directory>-->
-<!--    </testsuite>-->
+    <testsuite name="unit">
+      <directory suffix=".php">tests/Aeon/Automation/Tests/Unit</directory>
+    </testsuite>
     <testsuite name="integration">
       <directory suffix=".php">tests/Aeon/Automation/Tests/Integration</directory>
     </testsuite>

--- a/src/Aeon/Automation/ChangeLog/MarkdownFormatter.php
+++ b/src/Aeon/Automation/ChangeLog/MarkdownFormatter.php
@@ -6,6 +6,7 @@ namespace Aeon\Automation\ChangeLog;
 
 use Aeon\Automation\ChangeLog;
 use Aeon\Automation\Changes\Change;
+use Aeon\Automation\Changes\Type;
 use Aeon\Automation\ChangesSource;
 use Aeon\Automation\GitHub\Commit;
 
@@ -23,27 +24,27 @@ final class MarkdownFormatter implements Formatter
         $security = '';
 
         foreach ($changeLog->changes() as $changes) {
-            foreach ($changes->added() as $entry) {
+            foreach ($changes->withType(Type::added()) as $entry) {
                 $added .= $this->formatEntry($changes->source(), $entry);
             }
 
-            foreach ($changes->changed() as $entry) {
+            foreach ($changes->withType(Type::changed()) as $entry) {
                 $changed .= $this->formatEntry($changes->source(), $entry);
             }
 
-            foreach ($changes->fixed() as $entry) {
+            foreach ($changes->withType(Type::fixed()) as $entry) {
                 $fixed .= $this->formatEntry($changes->source(), $entry);
             }
 
-            foreach ($changes->deprecated() as $entry) {
+            foreach ($changes->withType(Type::deprecated()) as $entry) {
                 $deprecated .= $this->formatEntry($changes->source(), $entry);
             }
 
-            foreach ($changes->removed() as $entry) {
+            foreach ($changes->withType(Type::deprecated()) as $entry) {
                 $removed .= $this->formatEntry($changes->source(), $entry);
             }
 
-            foreach ($changes->security() as $entry) {
+            foreach ($changes->withType(Type::security()) as $entry) {
                 $security .= $this->formatEntry($changes->source(), $entry);
             }
         }

--- a/src/Aeon/Automation/Changes.php
+++ b/src/Aeon/Automation/Changes.php
@@ -14,55 +14,17 @@ final class Changes
     /**
      * @var Change[]
      */
-    private array $added;
+    private array $changes;
 
-    /**
-     * @var Change[]
-     */
-    private array $changed;
-
-    /**
-     * @var Change[]
-     */
-    private array $fixed;
-
-    /**
-     * @var Change[]
-     */
-    private array $removed;
-
-    /**
-     * @var Change[]
-     */
-    private array $deprecated;
-
-    /**
-     * @var Change[]
-     */
-    private array $security;
-
-    /**
-     * @param string[] $added
-     * @param string[] $changed
-     * @param string[] $fixed
-     * @param string[] $removed
-     * @param string[] $deprecated
-     * @param string[] $security
-     */
-    public function __construct(ChangesSource $source, array $added, array $changed, array $fixed, array $removed, array $deprecated, array $security)
+    public function __construct(ChangesSource $source, Change ...$changes)
     {
         $this->source = $source;
-        $this->added = \array_map(fn (string $message) : Change => new Change(Type::added(), $message), $added);
-        $this->changed = \array_map(fn (string $message) : Change => new Change(Type::changed(), $message), $changed);
-        $this->fixed = \array_map(fn (string $message) : Change => new Change(Type::fixed(), $message), $fixed);
-        $this->removed = \array_map(fn (string $message) : Change => new Change(Type::removed(), $message), $removed);
-        $this->deprecated = \array_map(fn (string $message) : Change => new Change(Type::deprecated(), $message), $deprecated);
-        $this->security = \array_map(fn (string $message) : Change => new Change(Type::security(), $message), $security);
+        $this->changes = $changes;
     }
 
     public function empty() : bool
     {
-        return (\count($this->added) + \count($this->changed) + \count($this->fixed) + \count($this->removed) + \count($this->deprecated) + \count($this->security)) === 0;
+        return \count($this->changes) === 0;
     }
 
     public function source() : ChangesSource
@@ -73,49 +35,9 @@ final class Changes
     /**
      * @return Change[]
      */
-    public function added() : array
+    public function withType(Type $type) : array
     {
-        return $this->added;
-    }
-
-    /**
-     * @return Change[]
-     */
-    public function changed() : array
-    {
-        return $this->changed;
-    }
-
-    /**
-     * @return Change[]
-     */
-    public function fixed() : array
-    {
-        return $this->fixed;
-    }
-
-    /**
-     * @return Change[]
-     */
-    public function removed() : array
-    {
-        return $this->removed;
-    }
-
-    /**
-     * @return Change[]
-     */
-    public function deprecated() : array
-    {
-        return $this->deprecated;
-    }
-
-    /**
-     * @return Change[]
-     */
-    public function security() : array
-    {
-        return $this->security;
+        return \array_values(\array_filter($this->changes, fn (Change $change) : bool => $change->type()->isEqual($type)));
     }
 
     /**
@@ -123,13 +45,6 @@ final class Changes
      */
     public function all() : array
     {
-        return \array_merge(
-            $this->added(),
-            $this->changed(),
-            $this->fixed(),
-            $this->removed(),
-            $this->deprecated(),
-            $this->security()
-        );
+        return $this->changes;
     }
 }

--- a/src/Aeon/Automation/Changes/ChangesParser/ConventionalCommitParser.php
+++ b/src/Aeon/Automation/Changes/ChangesParser/ConventionalCommitParser.php
@@ -48,71 +48,41 @@ final class ConventionalCommitParser implements ChangesParser
             case 'feat':
                 return new Changes(
                     $changesSource,
-                    [$message->getDescription()->toString()],
-                    [],
-                    [],
-                    [],
-                    [],
-                    []
-                );
-            case 'cs':
-            case 'fixed':
-            case 'fix':
-                return new Changes(
-                    $changesSource,
-                    [],
-                    [],
-                    [$message->getDescription()->toString()],
-                    [],
-                    [],
-                    []
-                );
-            case 'removed':
-            case 'rm':
-            case 'remove':
-                return new Changes(
-                    $changesSource,
-                    [],
-                    [],
-                    [],
-                    [$message->getDescription()->toString()],
-                    [],
-                    []
-                );
-            case 'dep':
-            case 'deprecated':
-            case 'deprecate':
-                return new Changes(
-                    $changesSource,
-                    [],
-                    [],
-                    [],
-                    [],
-                    [$message->getDescription()->toString()],
-                    []
-                );
-            case 'sec':
-            case 'security':
-                return new Changes(
-                    $changesSource,
-                    [],
-                    [],
-                    [],
-                    [],
-                    [],
-                    [$message->getDescription()->toString()]
+                    new Changes\Change(Changes\Type::added(), $message->getDescription()->toString()),
                 );
             case 'updated':
             case 'changed':
             case 'change':
                 return new Changes(
                     $changesSource,
-                    [],
-                    [$message->getDescription()->toString()],
-                    [],
-                    [],
-                    [],
-                    []
+                    new Changes\Change(Changes\Type::changed(), $message->getDescription()->toString())
+                );
+            case 'cs':
+            case 'fixed':
+            case 'fix':
+                return new Changes(
+                    $changesSource,
+                    new Changes\Change(Changes\Type::fixed(), $message->getDescription()->toString())
+                );
+            case 'removed':
+            case 'rm':
+            case 'remove':
+                return new Changes(
+                    $changesSource,
+                    new Changes\Change(Changes\Type::removed(), $message->getDescription()->toString())
+                );
+            case 'dep':
+            case 'deprecated':
+            case 'deprecate':
+                return new Changes(
+                    $changesSource,
+                    new Changes\Change(Changes\Type::deprecated(), $message->getDescription()->toString())
+                );
+            case 'sec':
+            case 'security':
+                return new Changes(
+                    $changesSource,
+                    new Changes\Change(Changes\Type::security(), $message->getDescription()->toString())
                 );
 
             default:

--- a/src/Aeon/Automation/Changes/ChangesParser/DefaultParser.php
+++ b/src/Aeon/Automation/Changes/ChangesParser/DefaultParser.php
@@ -19,12 +19,7 @@ final class DefaultParser implements ChangesParser
     {
         return new Changes(
             $changesSource,
-            [],
-            [$changesSource->title()],
-            [],
-            [],
-            [],
-            []
+            new Changes\Change(Changes\Type::changed(), $changesSource->title())
         );
     }
 }

--- a/src/Aeon/Automation/Changes/ChangesParser/HTMLChangesParser.php
+++ b/src/Aeon/Automation/Changes/ChangesParser/HTMLChangesParser.php
@@ -31,57 +31,19 @@ final class HTMLChangesParser implements ChangesParser
         $crawler = new Crawler('<html><body><div id="changes">' . $changesSource->description() . '</div></body></html>');
 
         if (!$crawler->filter('#change-log')->count()) {
-            return new Changes($changesSource, [], [$changesSource->title()], [], [], [], []);
+            throw new \RuntimeException("Invalid html format, can't extract changes");
         }
 
-        $added = [];
+        $changes = [];
 
-        if ($crawler->filter('ul#added')->count()) {
-            foreach ($crawler->filter('ul#added')->children('li') as $node) {
-                $added[] = $node->textContent;
+        foreach (Changes\Type::all() as $type) {
+            if ($crawler->filter('ul#' . $type->name())->count()) {
+                foreach ($crawler->filter('ul#' . $type->name())->children('li') as $node) {
+                    $changes[] = new Changes\Change($type, $node->textContent);
+                }
             }
         }
 
-        $changed = [];
-
-        if ($crawler->filter('ul#changed')->count()) {
-            foreach ($crawler->filter('ul#changed')->children('li') as $node) {
-                $changed[] = $node->textContent;
-            }
-        }
-
-        $fixed = [];
-
-        if ($crawler->filter('ul#fixed')->count()) {
-            foreach ($crawler->filter('ul#fixed')->children('li') as $node) {
-                $fixed[] = $node->textContent;
-            }
-        }
-
-        $removed = [];
-
-        if ($crawler->filter('ul#removed')->count()) {
-            foreach ($crawler->filter('ul#removed')->children('li') as $node) {
-                $removed[] = $node->textContent;
-            }
-        }
-
-        $deprecated = [];
-
-        if ($crawler->filter('ul#deprecated')->count()) {
-            foreach ($crawler->filter('ul#deprecated')->children('li') as $node) {
-                $deprecated[] = $node->textContent;
-            }
-        }
-
-        $security = [];
-
-        if ($crawler->filter('ul#security')->count()) {
-            foreach ($crawler->filter('ul#security')->children('li') as $node) {
-                $security[] = $node->textContent;
-            }
-        }
-
-        return new Changes($changesSource, $added, $changed, $fixed, $removed, $deprecated, $security);
+        return new Changes($changesSource, ...$changes);
     }
 }

--- a/src/Aeon/Automation/Changes/ChangesParser/PrefixParser.php
+++ b/src/Aeon/Automation/Changes/ChangesParser/PrefixParser.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Automation\Changes\ChangesParser;
+
+use Aeon\Automation\Changes;
+use Aeon\Automation\Changes\ChangesParser;
+use Aeon\Automation\ChangesSource;
+
+final class PrefixParser implements ChangesParser
+{
+    private const PREFIXES = [
+        'added' => ['add', 'added', 'adding'],
+        'changed' => ['change', 'changed', 'updated', 'replaced', 'bump'],
+        'fixed' => ['fix', 'fixed', 'fixing'],
+        'removed' => ['rm', 'removed', 'rem'],
+        'deprecated' => ['deprecated', 'dep'],
+        'security' => ['security', 'sec'],
+    ];
+
+    public function support(ChangesSource $changesSource) : bool
+    {
+        foreach (self::PREFIXES as $type => $prefixes) {
+            foreach ($prefixes as $prefix) {
+                if ($this->startsWith($prefix . ' ', \strtolower($changesSource->title()))) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public function parse(ChangesSource $changesSource) : Changes
+    {
+        foreach (self::PREFIXES as $type => $prefixes) {
+            foreach ($prefixes as $prefix) {
+                if ($this->startsWith($prefix . ' ', \strtolower($changesSource->title()))) {
+                    return new Changes(
+                        $changesSource,
+                        new Changes\Change(
+                            Changes\Type::$type(),
+                            \substr($changesSource->title(), \strlen($prefix) + 1)
+                        )
+                    );
+                }
+            }
+        }
+
+        throw new \RuntimeException("Can't get changes from source title prefix");
+    }
+
+    private function startsWith(string $needle, string $haystack) : bool
+    {
+        return \substr($haystack, 0, \strlen($needle)) === $needle;
+    }
+}

--- a/src/Aeon/Automation/Changes/Type.php
+++ b/src/Aeon/Automation/Changes/Type.php
@@ -54,4 +54,74 @@ final class Type
     {
         return new self(self::TYPE_SECURITY);
     }
+
+    /**
+     * @return Type[];
+     */
+    public static function all() : array
+    {
+        return [
+            self::added(),
+            self::changed(),
+            self::fixed(),
+            self::removed(),
+            self::deprecated(),
+            self::security(),
+        ];
+    }
+
+    public function isAdded() : bool
+    {
+        return $this->type === self::TYPE_ADDED;
+    }
+
+    public function isChanged() : bool
+    {
+        return $this->type === self::TYPE_CHANGED;
+    }
+
+    public function isFixed() : bool
+    {
+        return $this->type === self::TYPE_FIXED;
+    }
+
+    public function isRemoved() : bool
+    {
+        return $this->type === self::TYPE_REMOVED;
+    }
+
+    public function isDeprecated() : bool
+    {
+        return $this->type === self::TYPE_DEPRECATED;
+    }
+
+    public function isSecurity() : bool
+    {
+        return $this->type === self::TYPE_SECURITY;
+    }
+
+    public function name() : string
+    {
+        switch ($this->type) {
+            case self::TYPE_ADDED:
+                return 'added';
+            case self::TYPE_CHANGED:
+                return 'changed';
+            case self::TYPE_FIXED:
+                return 'fixed';
+            case self::TYPE_REMOVED:
+                return 'removed';
+            case self::TYPE_DEPRECATED:
+                return 'deprecated';
+            case self::TYPE_SECURITY:
+                return 'security';
+        }
+
+        throw new \RuntimeException('Missing type name definition');
+    }
+
+    public function isEqual(self $type) : bool
+    {
+        return $this->type === $type->type;
+    }
 }

--- a/src/Aeon/Automation/Console/Command/ChangeLogGet.php
+++ b/src/Aeon/Automation/Console/Command/ChangeLogGet.php
@@ -8,6 +8,7 @@ use Aeon\Automation\ChangeLog;
 use Aeon\Automation\Changes\ChangesParser\ConventionalCommitParser;
 use Aeon\Automation\Changes\ChangesParser\DefaultParser;
 use Aeon\Automation\Changes\ChangesParser\HTMLChangesParser;
+use Aeon\Automation\Changes\ChangesParser\PrefixParser;
 use Aeon\Automation\Changes\ChangesParser\PrioritizedParser;
 use Aeon\Automation\ChangesSource;
 use Aeon\Automation\Console\AeonStyle;
@@ -131,6 +132,7 @@ final class ChangeLogGet extends AbstractCommand
         $changesParser = new PrioritizedParser(
             new HTMLChangesParser(),
             new ConventionalCommitParser(),
+            new PrefixParser(),
             new DefaultParser()
         );
 

--- a/tests/Aeon/Automation/Tests/Mother/ChangesSourceMother.php
+++ b/tests/Aeon/Automation/Tests/Mother/ChangesSourceMother.php
@@ -5,9 +5,62 @@ declare(strict_types=1);
 namespace Aeon\Automation\Tests\Mother;
 
 use Aeon\Automation\ChangesSource;
+use Aeon\Calendar\Gregorian\DateTime;
 
 final class ChangesSourceMother
 {
+    public static function withTitle(string $title) : ChangesSource
+    {
+        return new class($title) implements ChangesSource {
+            private string $title;
+
+            public function __construct(string $content)
+            {
+                $this->title = $content;
+            }
+
+            public function id() : string
+            {
+                throw new \RuntimeException('not implemented');
+            }
+
+            public function url() : string
+            {
+                throw new \RuntimeException('not implemented');
+            }
+
+            public function title() : string
+            {
+                return $this->title;
+            }
+
+            public function date() : DateTime
+            {
+                throw new \RuntimeException('not implemented');
+            }
+
+            public function description() : string
+            {
+                return $this->title;
+            }
+
+            public function user() : string
+            {
+                throw new \RuntimeException('not implemented');
+            }
+
+            public function userUrl() : string
+            {
+                throw new \RuntimeException('not implemented');
+            }
+
+            public function equals(ChangesSource $source) : bool
+            {
+                throw new \RuntimeException('not implemented');
+            }
+        };
+    }
+
     public static function withContent(string $content) : ChangesSource
     {
         return new class($content) implements ChangesSource {
@@ -24,6 +77,16 @@ final class ChangesSourceMother
             }
 
             public function url() : string
+            {
+                throw new \RuntimeException('not implemented');
+            }
+
+            public function title() : string
+            {
+                throw new \RuntimeException('not implemented');
+            }
+
+            public function date() : DateTime
             {
                 throw new \RuntimeException('not implemented');
             }

--- a/tests/Aeon/Automation/Tests/Unit/Changes/ChangesParser/HTMLChangesParserTest.php
+++ b/tests/Aeon/Automation/Tests/Unit/Changes/ChangesParser/HTMLChangesParserTest.php
@@ -48,11 +48,11 @@ HTML;
 
         $changes = (new HTMLChangesParser())->parse(ChangesSourceMother::withContent($content));
 
-        $this->assertEquals([new Changes\Change(Changes\Type::added(), 'added')], $changes->added());
-        $this->assertEquals([new Changes\Change(Changes\Type::changed(), 'changed')], $changes->changed());
-        $this->assertEquals([new Changes\Change(Changes\Type::fixed(), 'fixed')], $changes->fixed());
-        $this->assertEquals([new Changes\Change(Changes\Type::removed(), 'removed')], $changes->removed());
-        $this->assertEquals([new Changes\Change(Changes\Type::deprecated(), 'deprecated')], $changes->deprecated());
-        $this->assertEquals([new Changes\Change(Changes\Type::security(), 'security')], $changes->security());
+        $this->assertEquals([new Changes\Change(Changes\Type::added(), 'added')], $changes->withType(Changes\Type::added()));
+        $this->assertEquals([new Changes\Change(Changes\Type::changed(), 'changed')], $changes->withType(Changes\Type::changed()));
+        $this->assertEquals([new Changes\Change(Changes\Type::fixed(), 'fixed')], $changes->withType(Changes\Type::fixed()));
+        $this->assertEquals([new Changes\Change(Changes\Type::removed(), 'removed')], $changes->withType(Changes\Type::removed()));
+        $this->assertEquals([new Changes\Change(Changes\Type::deprecated(), 'deprecated')], $changes->withType(Changes\Type::deprecated()));
+        $this->assertEquals([new Changes\Change(Changes\Type::security(), 'security')], $changes->withType(Changes\Type::security()));
     }
 }

--- a/tests/Aeon/Automation/Tests/Unit/Changes/ChangesParser/PrefixParserTest.php
+++ b/tests/Aeon/Automation/Tests/Unit/Changes/ChangesParser/PrefixParserTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeon\Automation\Tests\Unit\Changes\ChangesParser;
+
+use Aeon\Automation\Changes\Change;
+use Aeon\Automation\Changes\ChangesParser\PrefixParser;
+use Aeon\Automation\Changes\Type;
+use Aeon\Automation\Tests\Mother\ChangesSourceMother;
+use PHPUnit\Framework\TestCase;
+
+final class PrefixParserTest extends TestCase
+{
+    /**
+     * @dataProvider messages_without_prefix
+     */
+    public function test_support_for_invalid_format(string $message) : void
+    {
+        $this->assertFalse((new PrefixParser())->support(ChangesSourceMother::withTitle($message)));
+    }
+
+    public function messages_without_prefix() : \Generator
+    {
+        yield ['addingsomething cool'];
+        yield ['nothing cool and without prefix'];
+    }
+
+    /**
+     * @dataProvider messages_with_prefix
+     */
+    public function test_getting_changes_by_prefix(string $message, array $expectedChanges) : void
+    {
+        $this->assertTrue((new PrefixParser())->support(ChangesSourceMother::withTitle($message)));
+        $this->assertEquals($expectedChanges, (new PrefixParser())->parse(ChangesSourceMother::withTitle($message))->all());
+    }
+
+    public function messages_with_prefix() : \Generator
+    {
+        yield ['added something cool', [new Change(Type::added(), 'something cool')]];
+        yield ['AddEd something cool', [new Change(Type::added(), 'something cool')]];
+        yield ['adding something cool', [new Change(Type::added(), 'something cool')]];
+        yield ['changed so many different things', [new Change(Type::changed(), 'so many different things')]];
+        yield ['SecuRity so many different things', [new Change(Type::security(), 'so many different things')]];
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>PrefixParser to detect change type from change title prefix</li>
    <li>`Change::name() : string` and `Change::all() : array`  methods</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Replaced redundant methods in Changes collection with more generic ones</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

This is how it's going to look for [heiglandreas/holidayChecker](https://github.com/heiglandreas/holidayChecker),  @heiglandreas very strictly follows his pull requests naming convention. 

![image](https://user-images.githubusercontent.com/1921950/103381060-fb121100-4aea-11eb-8ec5-39e7d509d88a.png)

