### PR TITLE
Removed redundant branch parameter from changelog:generate command

### DIFF
--- a/tests/Aeon/Automation/Tests/Integration/Console/Command/ChangelogGenerateTest.php
+++ b/tests/Aeon/Automation/Tests/Integration/Console/Command/ChangelogGenerateTest.php
@@ -99,6 +99,9 @@ final class ChangelogGenerateTest extends CommandTestCase
             new HttpRequestStub('GET', '/repos/aeon-php/automation/branches/1.x', ResponseMother::jsonSuccess(
                 GitHubResponseMother::branch('1.x', $branchSHA = SHAMother::random())
             )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $branchSHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Unreleased 3', $branchSHA, '2021-01-01'),
+            )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/tags', ResponseMother::jsonSuccess([])),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits', ResponseMother::jsonSuccess(
                 [
@@ -140,7 +143,7 @@ final class ChangelogGenerateTest extends CommandTestCase
         $this->assertStringContainsString('Changelog - Generate', $commandTester->getDisplay());
         $this->assertStringContainsString('! [NOTE] Format: markdown', $commandTester->getDisplay());
         $this->assertStringContainsString('! [NOTE] Project: aeon-php/automation', $commandTester->getDisplay());
-        $this->assertStringContainsString('! [NOTE] Commit Start: N/A', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Commit Start: ' . $branchSHA, $commandTester->getDisplay());
         $this->assertStringContainsString('! [NOTE] Commit End: N/A', $commandTester->getDisplay());
         $this->assertStringContainsString('! [NOTE] Changes After: N/A', $commandTester->getDisplay());
         $this->assertStringContainsString('! [NOTE] Changes Before: N/A', $commandTester->getDisplay());
@@ -163,6 +166,9 @@ final class ChangelogGenerateTest extends CommandTestCase
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/branches/1.x', ResponseMother::jsonSuccess(
                 GitHubResponseMother::branch('1.x', $branchSHA = SHAMother::random())
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $branchSHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Unreleased 3', $branchSHA, '2021-01-01'),
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/tags', ResponseMother::jsonSuccess([])),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits', ResponseMother::jsonSuccess(
@@ -203,7 +209,7 @@ final class ChangelogGenerateTest extends CommandTestCase
         $this->assertStringContainsString('Changelog - Generate', $commandTester->getDisplay());
         $this->assertStringContainsString('! [NOTE] Format: markdown', $commandTester->getDisplay());
         $this->assertStringContainsString('! [NOTE] Project: aeon-php/automation', $commandTester->getDisplay());
-        $this->assertStringContainsString('! [NOTE] Commit Start: N/A', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Commit Start: ' . $branchSHA, $commandTester->getDisplay());
         $this->assertStringContainsString('! [NOTE] Commit End: N/A', $commandTester->getDisplay());
         $this->assertStringContainsString('! [NOTE] Changes After: N/A', $commandTester->getDisplay());
         $this->assertStringContainsString('! [NOTE] Changes Before: N/A', $commandTester->getDisplay());
@@ -226,6 +232,9 @@ final class ChangelogGenerateTest extends CommandTestCase
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/branches/1.x', ResponseMother::jsonSuccess(
                 GitHubResponseMother::branch('1.x', $branchSHA = SHAMother::random())
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $branchSHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Unreleased 3', $branchSHA, '2021-01-01'),
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/tags', ResponseMother::jsonSuccess([])),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits', ResponseMother::jsonSuccess(
@@ -259,7 +268,7 @@ final class ChangelogGenerateTest extends CommandTestCase
         $this->assertStringContainsString('Changelog - Generate', $commandTester->getDisplay());
         $this->assertStringContainsString('! [NOTE] Format: markdown', $commandTester->getDisplay());
         $this->assertStringContainsString('! [NOTE] Project: aeon-php/automation', $commandTester->getDisplay());
-        $this->assertStringContainsString('! [NOTE] Commit Start: N/A', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Commit Start: ' . $branchSHA, $commandTester->getDisplay());
         $this->assertStringContainsString('! [NOTE] Commit End: N/A', $commandTester->getDisplay());
         $this->assertStringContainsString('! [NOTE] Changes After: N/A', $commandTester->getDisplay());
         $this->assertStringContainsString('! [NOTE] Changes Before: N/A', $commandTester->getDisplay());
@@ -277,12 +286,6 @@ final class ChangelogGenerateTest extends CommandTestCase
     public function test_changelog_generate_for_given_tag() : void
     {
         $client = Client::createWithHttpClient($httpClient = $this->httpClient(
-            new HttpRequestStub('GET', '/repos/aeon-php/automation', ResponseMother::jsonSuccess(
-                GitHubResponseMother::repository('1.x')
-            )),
-            new HttpRequestStub('GET', '/repos/aeon-php/automation/branches/1.x', ResponseMother::jsonSuccess(
-                GitHubResponseMother::branch('1.x', $branchSHA = SHAMother::random())
-            )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/tags', ResponseMother::jsonSuccess([
                 GitHubResponseMother::tag('1.0.0', $tag100SHA = SHAMother::random()),
                 GitHubResponseMother::tag('1.1.0', $tag110SHA = SHAMother::random()),


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>redundant branch parameter from changelog:generate command</li>
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
