### PR TITLE
Added possibility to skip specific authors when generating changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ There are 2 more options that could help to setup the right scope, `--changed-af
 
 ### 2) Fetch Project History 
 
-When the scope is detected, Automation will fetch the history of changes from source. It all starts from commits and it works pretty much as `git log origin..HEAD` command. When commits are fetched, Automation pulls all Pull Requests since they also have valuable data about changes (this can be skipped using `--only-commits` option). 
+When the scope is detected, Automation will fetch the history of changes from source. It all starts from commits, and it works pretty much as `git log origin..HEAD` command. When commits are fetched, Automation pulls all Pull Requests since they also have valuable data about changes (this can be skipped using `--only-commits` option).
+Not all contributions are worth mentioning, sometimes you might want to exclude changes from bots. `--skip-from` option makes possible to skip changes from given authors. 
 
 ### 3) Analyze Project History 
 
@@ -195,26 +196,27 @@ Options:
   -gt, --github-token=GITHUB-TOKEN   Github personal access token, generated here: https://github.com/settings/tokens By default taken from AEON_AUTOMATION_GH_TOKEN env variable
 
 Available commands:
-  help                        Displays help for a command
-  list                        Lists commands
+  help                            Displays help for a command
+  list                            Lists commands
  branch
-  branch:list                 List project branches
+  branch:list                     List project branches
  cache
-  cache:clear                 Clears cache used to cache HTTP responses from GitHub
+  cache:clear                     Clears cache used to cache HTTP responses from GitHub
  changelog
-  changelog:generate          Generate change log for a release.
+  changelog:generate              Generate change log for a release.
  milestone
-  milestone:create            Create new milestone for project
-  milestone:list              
+  milestone:create                Create new milestone for project
+  milestone:list                  
  project
-  project:list                List all projects defined in automation.xml file
+  project:list                    List all projects defined in automation.xml file
  pull-request
-  pull-request:list           
-  pull-request:template:show  Display pull request template required by this tool to properly parse keepachangelog format
+  pull-request:description:check  Check if pull request has changes in expected by Automation format.
+  pull-request:list               
+  pull-request:template:show      Display pull request template required by this tool to properly parse keepachangelog format
  release
-  release:list                List all project releases
+  release:list                    List all project releases
  tag
-  tag:list                    Display all tags following SemVer convention sorted from the latest to oldest
+  tag:list                        Display all tags following SemVer convention sorted from the latest to oldest
 ```
 
 ### changelog:generate
@@ -230,9 +232,8 @@ Arguments:
   project                               project name, for example aeon-php/calendar
 
 Options:
-  -b, --branch=BRANCH                   Get the the branch used instead of tag-start option when it's not provided. If empty, default repository branch is taken.
   -t, --tag=TAG                         List only changes from given release
-  -f, --format=FORMAT                   How to format generated changelog, available formatters: "markdown" [default: "markdown"]
+  -f, --format=FORMAT                   How to format generated changelog, available formatters: "markdown", "html" [default: "markdown"]
   -h, --help                            Display help for the given command. When no command is given display help for the list command
   -q, --quiet                           Do not output any message
   -V, --version                         Display this application version
@@ -246,6 +247,8 @@ Options:
   -cb, --changed-before=CHANGED-BEFORE  Ignore all changes before given date, relative date formats like "-1 day" are also supported
   -oc, --only-commits                   Use only commits to generate changelog
   -opr, --only-pull-requests            Use only pull requests to generate changelog
+  -th, --theme=THEME                    Theme of generated changelog: "keepachangelog", "classic" [default: "keepachangelog"]
+  -sf, --skip-from=SKIP-FROM            Skip changes from given author|authors (multiple values allowed)
   -v|vv|vvv, --verbose                  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
   -gt, --github-token=GITHUB-TOKEN      Github personal access token, generated here: https://github.com/settings/tokens By default taken from AEON_AUTOMATION_GH_TOKEN env variable
 

--- a/src/Aeon/Automation/ChangesSource.php
+++ b/src/Aeon/Automation/ChangesSource.php
@@ -18,6 +18,8 @@ interface ChangesSource
 
     public function user() : string;
 
+    public function isFrom(string ...$users) : bool;
+
     public function userUrl() : string;
 
     public function equals(self $source) : bool;

--- a/src/Aeon/Automation/GitHub/Commit.php
+++ b/src/Aeon/Automation/GitHub/Commit.php
@@ -71,6 +71,17 @@ final class Commit implements ChangesSource
         return $this->data['commit']['author']['email'];
     }
 
+    public function isFrom(string ...$users) : bool
+    {
+        foreach ($users as $user) {
+            if (\strtolower(\trim($this->user())) === \strtolower(\trim($user))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function userUrl() : string
     {
         if (!isset($this->data['author']['html_url'])) {

--- a/src/Aeon/Automation/GitHub/PullRequest.php
+++ b/src/Aeon/Automation/GitHub/PullRequest.php
@@ -58,6 +58,17 @@ final class PullRequest implements ChangesSource
         return $this->data['user']['login'];
     }
 
+    public function isFrom(string ...$users) : bool
+    {
+        foreach ($users as $user) {
+            if (\strtolower(\trim($this->user())) === \strtolower(\trim($user))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function userUrl() : string
     {
         return $this->data['user']['html_url'];

--- a/tests/Aeon/Automation/Tests/Mother/ChangesSourceMother.php
+++ b/tests/Aeon/Automation/Tests/Mother/ChangesSourceMother.php
@@ -49,6 +49,11 @@ final class ChangesSourceMother
                 throw new \RuntimeException('not implemented');
             }
 
+            public function isFrom(string ...$users) : bool
+            {
+                throw new \RuntimeException('not implemented');
+            }
+
             public function userUrl() : string
             {
                 throw new \RuntimeException('not implemented');
@@ -97,6 +102,11 @@ final class ChangesSourceMother
             }
 
             public function user() : string
+            {
+                throw new \RuntimeException('not implemented');
+            }
+
+            public function isFrom(string ...$users) : bool
             {
                 throw new \RuntimeException('not implemented');
             }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>--skip-from option to changelog:generate command that makes possible to skip bots when generating changelogs</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

## Before
![image](https://user-images.githubusercontent.com/1921950/103826834-ecda6c80-5077-11eb-9c5e-a66208aebd79.png)

## After
![image](https://user-images.githubusercontent.com/1921950/103826855-f9f75b80-5077-11eb-9436-5d1554bf0caf.png)
