### PR TITLE
Added possibility to specify next tag and make reverse commits comparision

### DIFF
--- a/tests/Aeon/Automation/Tests/Integration/Console/Command/ChangelogGenerateTest.php
+++ b/tests/Aeon/Automation/Tests/Integration/Console/Command/ChangelogGenerateTest.php
@@ -435,4 +435,155 @@ final class ChangelogGenerateTest extends CommandTestCase
 
         $this->assertSame(0, $commandTester->getStatusCode());
     }
+
+    public function test_changelog_generate_for_given_tag_and_tag_next() : void
+    {
+        $client = Client::createWithHttpClient($httpClient = $this->httpClient(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/tags', ResponseMother::jsonSuccess([
+                GitHubResponseMother::tag('tag-1.0.0', $tag100SHA = SHAMother::random()),
+                GitHubResponseMother::tag('tag-1.1.0', $tag110SHA = SHAMother::random()),
+            ])),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/tag-1.1.0', ResponseMother::jsonSuccess(
+                GitHubResponseMother::refCommit('tags/tag-1.1.0', $tag110SHA)
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/tag-1.0.0', ResponseMother::jsonSuccess(
+                GitHubResponseMother::refCommit('tags/tag-1.0.0', $tag100SHA)
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $tag110SHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Tag 1.1.0', $tag110SHA, '2021-01-01'),
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $tag100SHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Tag 1.0.0', $tag100SHA),
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/compare/' . $tag100SHA . '...' . $tag110SHA, ResponseMother::jsonSuccess(
+                [
+                    'total_commits' => 3,
+                    'commits' => [
+                        GitHubResponseMother::commit('Release 1.1.0 - 1', $unreleased1 = SHAMother::random()),
+                        GitHubResponseMother::commit('Release 1.1.0 - 2', $unreleased2 = SHAMother::random()),
+                        GitHubResponseMother::commit('Release 1.1.0 - 3 ', $tag110SHA),
+                    ],
+                ]
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $tag110SHA . '/pulls', ResponseMother::jsonSuccess(
+                [GitHubResponseMother::pullRequest(3, 'Release 1.1.0 Title - 3')]
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $unreleased2 . '/pulls', ResponseMother::jsonSuccess(
+                [GitHubResponseMother::pullRequest(2, 'Release 1.1.0 Title - 2')]
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $unreleased1 . '/pulls', ResponseMother::jsonSuccess(
+                [GitHubResponseMother::pullRequest(1, 'Release 1.1.0 Title - 1')]
+            )),
+        ));
+
+        $command = new ChangelogGenerate(\getenv('AUTOMATION_ROOT_DIR'));
+        $command->setGithub($client);
+
+        $application = new AeonApplication();
+        $application->add($command);
+
+        $commandTester = new CommandTester($application->get(ChangelogGenerate::getDefaultName()));
+
+        $commandTester->setInputs(['verbosity' => ConsoleOutput::VERBOSITY_VERY_VERBOSE]);
+
+        $commandTester->execute(
+            ['project' => 'aeon-php/automation', '--tag' => 'tag-1.1.0', '--tag-next' => 'tag-1.0.0'],
+            ['verbosity' => ConsoleOutput::VERBOSITY_VERBOSE]
+        );
+
+        $this->assertStringContainsString('Changelog - Generate', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Release: tag-1.1.0', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Project: aeon-php/automation', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Format: markdown', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Theme: keepachangelog', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Tag: tag-1.1.0', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Tag End: tag-1.0.0', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Commit Start: ' . $tag110SHA, $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Commit End: ' . $tag100SHA, $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Total commits: 3', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] All commits analyzed, generating changelog:', $commandTester->getDisplay());
+        $this->assertStringContainsString('## [tag-1.1.0] - 2021-01-01', $commandTester->getDisplay());
+        $this->assertStringContainsString('### Changed', $commandTester->getDisplay());
+        $this->assertStringContainsString(' - [#3](http://api.github.com) - **Release 1.1.0 Title - 3**', $commandTester->getDisplay());
+        $this->assertStringContainsString(' - [#2](http://api.github.com) - **Release 1.1.0 Title - 2**', $commandTester->getDisplay());
+        $this->assertStringContainsString(' - [#1](http://api.github.com) - **Release 1.1.0 Title - 1**', $commandTester->getDisplay());
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function test_changelog_generate_for_given_tag_and_tag_next_with_reverse_commit() : void
+    {
+        $client = Client::createWithHttpClient($httpClient = $this->httpClient(
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/tags', ResponseMother::jsonSuccess([
+                GitHubResponseMother::tag('tag-1.0.0', $tag100SHA = SHAMother::random()),
+                GitHubResponseMother::tag('tag-1.1.0', $tag110SHA = SHAMother::random()),
+            ])),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/tag-1.1.0', ResponseMother::jsonSuccess(
+                GitHubResponseMother::refCommit('tags/tag-1.1.0', $tag110SHA)
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/git/refs/tags/tag-1.0.0', ResponseMother::jsonSuccess(
+                GitHubResponseMother::refCommit('tags/tag-1.0.0', $tag100SHA)
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $tag110SHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Tag 1.1.0', $tag110SHA, '2021-01-01'),
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $tag100SHA, ResponseMother::jsonSuccess(
+                GitHubResponseMother::commit('Tag 1.0.0', $tag100SHA, '2021-01-01'),
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/compare/' . $tag110SHA . '...' . $tag100SHA, ResponseMother::jsonSuccess(
+                [
+                    'total_commits' => 3,
+                    'commits' => [
+                        GitHubResponseMother::commit('Release 1.1.0 - 1', $unreleased1 = SHAMother::random()),
+                        GitHubResponseMother::commit('Release 1.1.0 - 2', $unreleased2 = SHAMother::random()),
+                        GitHubResponseMother::commit('Release 1.1.0 - 3 ', $tag110SHA),
+                    ],
+                ]
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $tag110SHA . '/pulls', ResponseMother::jsonSuccess(
+                [GitHubResponseMother::pullRequest(3, 'Release 1.1.0 Title - 3')]
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $unreleased2 . '/pulls', ResponseMother::jsonSuccess(
+                [GitHubResponseMother::pullRequest(2, 'Release 1.1.0 Title - 2')]
+            )),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $unreleased1 . '/pulls', ResponseMother::jsonSuccess(
+                [GitHubResponseMother::pullRequest(1, 'Release 1.1.0 Title - 1')]
+            )),
+        ));
+
+        $command = new ChangelogGenerate(\getenv('AUTOMATION_ROOT_DIR'));
+        $command->setGithub($client);
+
+        $application = new AeonApplication();
+        $application->add($command);
+
+        $commandTester = new CommandTester($application->get(ChangelogGenerate::getDefaultName()));
+
+        $commandTester->setInputs(['verbosity' => ConsoleOutput::VERBOSITY_VERY_VERBOSE]);
+
+        $commandTester->execute(
+            ['project' => 'aeon-php/automation', '--tag' => 'tag-1.1.0', '--tag-next' => 'tag-1.0.0', '--compare-reverse' => true],
+            ['verbosity' => ConsoleOutput::VERBOSITY_VERBOSE]
+        );
+
+        $this->assertStringContainsString('Changelog - Generate', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Release: tag-1.1.0', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Project: aeon-php/automation', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Format: markdown', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Theme: keepachangelog', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Tag: tag-1.1.0', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Tag End: tag-1.0.0', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Reversed Start with End commit', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Commit Start: ' . $tag100SHA . ' - reversed', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Commit End: ' . $tag110SHA . ' - reversed', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] Total commits: 3', $commandTester->getDisplay());
+        $this->assertStringContainsString('! [NOTE] All commits analyzed, generating changelog:', $commandTester->getDisplay());
+        $this->assertStringContainsString('## [tag-1.1.0] - 2021-01-01', $commandTester->getDisplay());
+        $this->assertStringContainsString('### Changed', $commandTester->getDisplay());
+        $this->assertStringContainsString(' - [#3](http://api.github.com) - **Release 1.1.0 Title - 3**', $commandTester->getDisplay());
+        $this->assertStringContainsString(' - [#2](http://api.github.com) - **Release 1.1.0 Title - 2**', $commandTester->getDisplay());
+        $this->assertStringContainsString(' - [#1](http://api.github.com) - **Release 1.1.0 Title - 1**', $commandTester->getDisplay());
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+    }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>--tag-next option that will overwrite guessing End Commit SHA when detecting scope changes</li>
    <li>--compare-reverse option that will reverse start with end commit before comparison</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Both options are added to support projects that do not follow the Semantic Versioning convention, like for example PHP source code: 

![image](https://user-images.githubusercontent.com/1921950/103893533-bdfedd80-50ed-11eb-8337-f689909d72b0.png)

