### PR TITLE
Do not display output when there are no changes in changelog

### DIFF
--- a/src/Aeon/Automation/Console/Command/ChangelogGenerate.php
+++ b/src/Aeon/Automation/Console/Command/ChangelogGenerate.php
@@ -173,7 +173,11 @@ final class ChangelogGenerate extends AbstractCommand
 
         $io->note('All commits analyzed, generating changelog: ');
 
-        $io->write($formatter->format($release));
+        if (!$release->empty()) {
+            $io->write($formatter->format($release));
+        } else {
+            $io->note('No changes');
+        }
 
         return Command::SUCCESS;
     }

--- a/src/Aeon/Automation/Release.php
+++ b/src/Aeon/Automation/Release.php
@@ -128,4 +128,9 @@ final class Release
             ...\array_map(fn (Changes $changes) => $changes->withType(Type::security()), $this->changes())
         );
     }
+
+    public function empty() : bool
+    {
+        return \count($this->all()) === 0;
+    }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Do not display output when there are no changes in changelog</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
