### PR TITLE
Added --github-release-update option

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Options:
   -cpr, --compare-reverse               When comparing commits, revers the order and compare start to end, instead end to start.
   -th, --theme=THEME                    Theme of generated changelog: "keepachangelog", "classic" [default: "keepachangelog"]
   -sf, --skip-from=SKIP-FROM            Skip changes from given author|authors (multiple values allowed)
+  -gru, --github-release-update         Update GitHub release description if you have right permissions and release exists
   -v|vv|vvv, --verbose                  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
   -gt, --github-token=GITHUB-TOKEN      Github personal access token, generated here: https://github.com/settings/tokens By default taken from AEON_AUTOMATION_GH_TOKEN env variable
 
@@ -289,6 +290,7 @@ Options:
   -opr, --only-pull-requests         Use only pull requests to generate changelog
   -cpr, --compare-reverse            When comparing commits, revers the order and compare start to end, instead end to start.
   -th, --theme=THEME                 Theme of generated changelog: "keepachangelog", "classic" [default: "keepachangelog"]
+  -gru, --github-release-update      Update GitHub release description if you have right permissions and release exists
   -v|vv|vvv, --verbose               Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
   -gt, --github-token=GITHUB-TOKEN   Github personal access token, generated here: https://github.com/settings/tokens By default taken from AEON_AUTOMATION_GH_TOKEN env variable
 

--- a/resources/templates/markdown/classic/changelog/changes.md.twig
+++ b/resources/templates/markdown/classic/changelog/changes.md.twig
@@ -2,9 +2,9 @@
 
 {% for change in changes %}
 {% if change.source | is_commit %}
-  - [{{ change.source.id | slice(0, 6) }}]({{ change.source.url }}) - **{{ change.description }}** - [@{{ change.source.user }}]({{ change.source.userUrl }})
+  - [{{ change.source.id | slice(0, 6) }}]({{ change.source.url }}) - **{{ change.description|trim }}** - [@{{ change.source.user }}]({{ change.source.userUrl }})
 {% elseif change.source | is_pr %}
-  - [#{{ change.source.id }}]({{ change.source.url }}) - **{{ change.description }}** - [@{{ change.source.user }}]({{ change.source.userUrl }})
+  - [#{{ change.source.id }}]({{ change.source.url }}) - **{{ change.description|trim }}** - [@{{ change.source.user }}]({{ change.source.userUrl }})
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/resources/templates/markdown/keepachangelog/changelog/changes.md.twig
+++ b/resources/templates/markdown/keepachangelog/changelog/changes.md.twig
@@ -3,9 +3,9 @@
 ### {{ type | capitalize }}
 {% for change in changes %}
 {% if change.source | is_commit %}
-  - [{{ change.source.id | slice(0, 6) }}]({{ change.source.url }}) - **{{ change.description }}** - [@{{ change.source.user }}]({{ change.source.userUrl }})
+  - [{{ change.source.id | slice(0, 6) }}]({{ change.source.url }}) - **{{ change.description|trim }}** - [@{{ change.source.user }}]({{ change.source.userUrl }})
 {% elseif change.source | is_pr %}
-  - [#{{ change.source.id }}]({{ change.source.url }}) - **{{ change.description }}** - [@{{ change.source.user }}]({{ change.source.userUrl }})
+  - [#{{ change.source.id }}]({{ change.source.url }}) - **{{ change.description|trim }}** - [@{{ change.source.user }}]({{ change.source.userUrl }})
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/src/Aeon/Automation/GitHub/GitHub.php
+++ b/src/Aeon/Automation/GitHub/GitHub.php
@@ -37,6 +37,10 @@ interface GitHub
 
     public function releases(Project $project) : Releases;
 
+    public function release(Project $project, int $id) : Release;
+
+    public function updateRelease(Project $project, int $id, ?string $body = null) : Release;
+
     public function tags(Project $project) : Tags;
 
     public function tagCommit(Project $project, Tag $tag) : Commit;

--- a/src/Aeon/Automation/GitHub/GitHubClient.php
+++ b/src/Aeon/Automation/GitHub/GitHubClient.php
@@ -229,6 +229,22 @@ final class GitHubClient implements GitHub
         ));
     }
 
+    public function release(Project $project, int $id) : Release
+    {
+        return new Release($this->client->repository()->releases()->show($project->organization(), $project->name(), $id));
+    }
+
+    public function updateRelease(Project $project, int $id, ?string $body = null) : Release
+    {
+        $parameters = [];
+
+        if ($body !== null) {
+            $parameters['body'] = $body;
+        }
+
+        return new Release($this->client->repository()->releases()->edit($project->organization(), $project->name(), $id, $parameters));
+    }
+
     public function tags(Project $project) : Tags
     {
         $tagsPaginator = new ResultPager($this->client);

--- a/src/Aeon/Automation/GitHub/Release.php
+++ b/src/Aeon/Automation/GitHub/Release.php
@@ -17,4 +17,9 @@ final class Release
     {
         return $this->data['name'];
     }
+
+    public function id() : int
+    {
+        return $this->data['id'];
+    }
 }

--- a/src/Aeon/Automation/GitHub/Releases.php
+++ b/src/Aeon/Automation/GitHub/Releases.php
@@ -131,4 +131,15 @@ final class Releases
 
         return false;
     }
+
+    public function get(string $name) : Release
+    {
+        foreach ($this->releases as $release) {
+            if ($release->name() === $name) {
+                return $release;
+            }
+        }
+
+        throw new \RuntimeException('Release ' . $name . ' not found');
+    }
 }

--- a/tests/Aeon/Automation/Tests/Integration/Console/Command/ChangelogGenerateAllTest.php
+++ b/tests/Aeon/Automation/Tests/Integration/Console/Command/ChangelogGenerateAllTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 final class ChangelogGenerateAllTest extends CommandTestCase
 {
-    public function test_changelog_generate_without_parameters_with_tags() : void
+    public function test_changelog_generate_all_with_github_release_update() : void
     {
         $client = Client::createWithHttpClient($httpClient = $this->httpClient(
             new HttpRequestStub('GET', '/repos/aeon-php/automation', ResponseMother::jsonSuccess(
@@ -79,6 +79,14 @@ final class ChangelogGenerateAllTest extends CommandTestCase
             )),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $commit1Tag100 . '/pulls', ResponseMother::jsonSuccess([])),
             new HttpRequestStub('GET', '/repos/aeon-php/automation/commits/' . $commit2Tag100 . '/pulls', ResponseMother::jsonSuccess([])),
+            new HttpRequestStub('GET', '/repos/aeon-php/automation/releases', ResponseMother::jsonSuccess([
+                GitHubResponseMother::release(3, '1.2.0'),
+                GitHubResponseMother::release(2, '1.1.0'),
+                GitHubResponseMother::release(1, '1.0.0'),
+            ])),
+            new HttpRequestStub('PATCH', '/repos/aeon-php/automation/releases/3', ResponseMother::jsonSuccess([])),
+            new HttpRequestStub('PATCH', '/repos/aeon-php/automation/releases/2', ResponseMother::jsonSuccess([])),
+            new HttpRequestStub('PATCH', '/repos/aeon-php/automation/releases/1', ResponseMother::jsonSuccess([])),
         ));
 
         $command = new ChangelogGenerateAll(\getenv('AUTOMATION_ROOT_DIR'));
@@ -92,7 +100,7 @@ final class ChangelogGenerateAllTest extends CommandTestCase
         $commandTester->setInputs(['verbosity' => ConsoleOutput::VERBOSITY_VERY_VERBOSE]);
 
         $commandTester->execute(
-            ['project' => 'aeon-php/automation'],
+            ['project' => 'aeon-php/automation', '--github-release-update' => true],
             ['verbosity' => ConsoleOutput::VERBOSITY_VERBOSE]
         );
 

--- a/tests/Aeon/Automation/Tests/Integration/Console/CommandTestCase.php
+++ b/tests/Aeon/Automation/Tests/Integration/Console/CommandTestCase.php
@@ -35,7 +35,7 @@ abstract class CommandTestCase extends TestCase
                         }
                     }
 
-                    return ResponseMother::json404('Invalid Path: ' . $request->getUri()->getPath());
+                    return ResponseMother::json404('Invalid Path: ' . $request->getMethod() . ' : ' . $request->getUri()->getPath());
                 })
             );
 

--- a/tests/Aeon/Automation/Tests/Mother/GitHub/GitHubResponseMother.php
+++ b/tests/Aeon/Automation/Tests/Mother/GitHub/GitHubResponseMother.php
@@ -114,4 +114,12 @@ final class GitHubResponseMother
             'completed_at' => $status === 'completed' ? DateTime::fromString($completedAt)->toISO8601() : null,
         ];
     }
+
+    public static function release(int $id, string $name) : array
+    {
+        return [
+            'id' => $id,
+            'name' => $name,
+        ];
+    }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Added --github-release-update option</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>trim change description in each changelog entry</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->

I already updated releases of all https://github.com/aeon-php projects 🙌
