### PR TITLE
Restore automation cache in Automation github workflow

### DIFF
--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -7,7 +7,7 @@ name: "Changelog - Update Unreleased"
 on:
   push:
     branches:
-      - main
+      - 1.x
 
 jobs:
   changelog-update-unreleased:
@@ -16,6 +16,15 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
+      - name: "Restore Automation cache"
+        uses: "actions/cache@v2"
+        with:
+          path: |
+            ~/.automation
+          key: "${{ runner.os }}-automation-"
+          restore-keys: |
+            ${{ runner.os }}-automation-
+
       - name: "Update CHANGELOG"
         uses: "docker://aeonphp/automation:latest"
         env:


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>keep automation cache between changelog update workflows execution</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>automation workflow target branch</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
