### PR TITLE
Use pagination in commits compare endpoint instead of previous hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ automation changelog:generate organization/name -v
 Looking for a way to contribute? Awesome ❤️ Below you can find few places to start with:
 
 * [Contributing & Development](https://github.com/aeon-php/.github/blob/master/CONTRIBUTING.md)
-* [Forum](https://forum.aeon-php.org/)
 
 You are also more than welcome to open an [issue](https://github.com/aeon-php/automation/issues) if anything about this project bothers you.
 

--- a/src/Aeon/Automation/GitHub/Commits.php
+++ b/src/Aeon/Automation/GitHub/Commits.php
@@ -45,4 +45,9 @@ final class Commits
 
         return new self(...\array_slice($this->commits, $commits, $this->count() -1));
     }
+
+    public function reverse() : self
+    {
+        return new self(...\array_reverse($this->all()));
+    }
 }

--- a/src/Aeon/Automation/Release/History.php
+++ b/src/Aeon/Automation/Release/History.php
@@ -55,7 +55,7 @@ final class History
         }
 
         if ($this->scope->commitStart() !== null && $this->scope->commitEnd() !== null) {
-            $this->commits = $this->github->commitsCompare($this->project, $this->scope->commitStart(), $this->scope->commitEnd(), $this->changedAfter, $this->changedBefore);
+            $this->commits = $this->github->commitsCompare($this->project, $this->scope->commitStart(), $this->scope->commitEnd(), $this->changedAfter, $this->changedBefore)->reverse();
         } else {
             $this->commits = $this->github->commits($this->project, $this->scope->commitStart()->sha(), $this->changedAfter, $this->changedBefore);
         }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Use pagination in commits compare endpoint</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
