### PR TITLE
Fixed skipping updated type in changelog formatter

### DIFF
--- a/src/Aeon/Automation/Release.php
+++ b/src/Aeon/Automation/Release.php
@@ -133,6 +133,14 @@ final class Release
     /**
      * @return Change[]
      */
+    public function updated() : array
+    {
+        return $this->sortChanges(Type::updated());
+    }
+
+    /**
+     * @return Change[]
+     */
     public function fixed() : array
     {
         return $this->sortChanges(Type::fixed());

--- a/tests/Aeon/Automation/Tests/Mother/Changes/ChangeMother.php
+++ b/tests/Aeon/Automation/Tests/Mother/Changes/ChangeMother.php
@@ -62,4 +62,31 @@ final class ChangeMother
             $description
         );
     }
+
+    public static function commitRemoved(string $sha, string $description, string $user) : Change
+    {
+        return new Change(
+            ChangesSourceMother::commit($sha, $user),
+            Type::removed(),
+            $description
+        );
+    }
+
+    public static function commitUpdated(string $sha, string $description, string $user) : Change
+    {
+        return new Change(
+            ChangesSourceMother::commit($sha, $user),
+            Type::updated(),
+            $description
+        );
+    }
+
+    public static function commitSecurity(string $sha, string $description, string $user) : Change
+    {
+        return new Change(
+            ChangesSourceMother::commit($sha, $user),
+            Type::security(),
+            $description
+        );
+    }
 }

--- a/tests/Aeon/Automation/Tests/Unit/ReleaseTest.php
+++ b/tests/Aeon/Automation/Tests/Unit/ReleaseTest.php
@@ -56,4 +56,24 @@ final class ReleaseTest extends TestCase
         $this->assertFalse($release1->isEqual($release2));
         $this->assertFalse($release2->isEqual($release1));
     }
+
+    public function test_detecting_all_changes() : void
+    {
+        $release = new Release('Unreleased', Day::fromString('2021-01-09'));
+
+        $release->add(new Changes(ChangeMother::commitChanged(SHAMother::random(), 'changed 1', 'user')));
+        $release->add(new Changes(ChangeMother::commitAdded(SHAMother::random(), 'added 1', 'user')));
+        $release->add(new Changes(ChangeMother::commitFixed(SHAMother::random(), 'fixed 1', 'user')));
+        $release->add(new Changes(ChangeMother::commitRemoved(SHAMother::random(), 'removed 1', 'user')));
+        $release->add(new Changes(ChangeMother::commitSecurity(SHAMother::random(), 'security 1', 'user')));
+        $release->add(new Changes(ChangeMother::commitUpdated(SHAMother::random(), 'updated 1', 'user')));
+
+        $this->assertCount(6, $release->changes());
+        $this->assertCount(1, $release->added());
+        $this->assertCount(1, $release->fixed());
+        $this->assertCount(1, $release->changed());
+        $this->assertCount(1, $release->security());
+        $this->assertCount(1, $release->removed());
+        $this->assertCount(1, $release->updated());
+    }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>skipping updated type in changelog formatter</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Updated</h4>
  <ul id="updated">
    <!-- <li>Something, for example, version of dependency</li> -->
  </ul>    
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
